### PR TITLE
T27: Like posts frontend

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,16 +3,19 @@ import Timeline from "./pages/Timeline";
 import { Route, Routes } from "react-router-dom";
 import NavBar from "./components/NavBar/NavBar";
 import "./App.css";
+import { PostContextProvider } from "./context/PostContext";
 
 function App() {
   return (
-    <div className="App" style={{ display: "flex" }}>
-      <NavBar />
-      <Routes>
-        <Route path="/" element={<Welcome />} />
-        <Route path="/home" element={<Timeline />} />
-      </Routes>
-    </div>
+    <PostContextProvider>
+      <div className="App" style={{ display: "flex" }}>
+        <NavBar />
+        <Routes>
+          <Route path="/" element={<Welcome />} />
+          <Route path="/home" element={<Timeline />} />
+        </Routes>
+      </div>
+    </PostContextProvider>
   );
 }
 

--- a/src/components/Posts/ComposePost.tsx
+++ b/src/components/Posts/ComposePost.tsx
@@ -36,6 +36,7 @@ const ComposePost = () => {
         textContent,
       });
       setPostTextContent("");
+      // TODO: Update posts in postContext so that the page rerenders rather than refreshing
       window.location.reload();
     } catch (err) {
       console.log(err);

--- a/src/components/Posts/PostItem.tsx
+++ b/src/components/Posts/PostItem.tsx
@@ -7,10 +7,12 @@ import CardMedia from "@mui/material/CardMedia/CardMedia";
 import CardActions from "@mui/material/CardActions/CardActions";
 import CardActionArea from "@mui/material/CardActionArea/CardActionArea";
 import FavoriteBorderOutlinedIcon from "@mui/icons-material/FavoriteBorderOutlined";
+import FavoriteOutlinedIcon from "@mui/icons-material/FavoriteOutlined";
 import AddCommentOutlinedIcon from "@mui/icons-material/AddCommentOutlined";
 import RepeatOutlinedIcon from "@mui/icons-material/RepeatOutlined";
 import ShareOutlinedIcon from "@mui/icons-material/ShareOutlined";
 import { Post } from "./PostList";
+import axios from "axios";
 
 const styles = {
   card: {
@@ -26,6 +28,22 @@ const styles = {
 
 type PostProps = {
   post: Post;
+};
+
+const likePost = async (userId: number, postId: number) => {
+  await axios.post("http://localhost:3001/api/posts/likePost", {
+    postId,
+    userId,
+  });
+};
+
+const unlikePost = async (userId: number, postId: number) => {
+  await axios.delete("http://localhost:3001/api/posts/unlikePost", {
+    params: {
+      postId,
+      userId,
+    },
+  });
 };
 
 const PostItem = ({ post }: PostProps) => {
@@ -59,9 +77,23 @@ const PostItem = ({ post }: PostProps) => {
           justifyContent="space-between"
           sx={styles.cardActions}
         >
-          <IconButton>
-            <FavoriteBorderOutlinedIcon />
-            <Typography sx={styles.actionNumbers}>1</Typography>
+          <IconButton
+            onClick={() => {
+              post.isLikedByCurrentUser
+                ? unlikePost(1, post.postId)
+                : likePost(1, post.postId);
+              // Temporary, need to look into a better way of state management like Redux
+              window.location.reload();
+            }}
+          >
+            {post.isLikedByCurrentUser ? (
+              <FavoriteOutlinedIcon />
+            ) : (
+              <FavoriteBorderOutlinedIcon />
+            )}
+            <Typography sx={styles.actionNumbers}>
+              {post.numberOfLikes}
+            </Typography>
           </IconButton>
           <IconButton>
             <AddCommentOutlinedIcon />

--- a/src/components/Posts/PostItem.tsx
+++ b/src/components/Posts/PostItem.tsx
@@ -13,6 +13,7 @@ import RepeatOutlinedIcon from "@mui/icons-material/RepeatOutlined";
 import ShareOutlinedIcon from "@mui/icons-material/ShareOutlined";
 import { Post } from "./PostList";
 import axios from "axios";
+import { usePostContext } from "../../context/PostContext";
 
 const styles = {
   card: {
@@ -47,6 +48,7 @@ const unlikePost = async (userId: number, postId: number) => {
 };
 
 const PostItem = ({ post }: PostProps) => {
+  const { updatePost } = usePostContext();
   return (
     <Card sx={styles.card}>
       <CardHeader
@@ -82,8 +84,14 @@ const PostItem = ({ post }: PostProps) => {
               post.isLikedByCurrentUser
                 ? unlikePost(1, post.postId)
                 : likePost(1, post.postId);
-              // Temporary, need to look into a better way of state management like Redux
-              window.location.reload();
+              const updatedPost = {
+                ...post,
+                isLikedByCurrentUser: !post.isLikedByCurrentUser,
+                numberOfLikes: post.isLikedByCurrentUser
+                  ? post.numberOfLikes - 1
+                  : post.numberOfLikes + 1,
+              };
+              updatePost(updatedPost);
             }}
           >
             {post.isLikedByCurrentUser ? (

--- a/src/components/Posts/PostList.tsx
+++ b/src/components/Posts/PostList.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import PostItem from "./PostItem";
 import axios from "axios";
+import { usePostContext } from "../../context/PostContext";
 
 export type Post = {
   displayName: string;
@@ -14,7 +15,7 @@ export type Post = {
 };
 
 const Timeline = () => {
-  const [posts, setPosts] = useState<Post[]>([]);
+  const { posts, setPosts } = usePostContext();
 
   useEffect(() => {
     const fetchPosts = async () => {
@@ -26,11 +27,10 @@ const Timeline = () => {
       setPosts(result.data as Post[]);
     };
     fetchPosts();
-  }, []);
+  }, [setPosts]);
 
   return (
     <>
-      {console.log(posts)}
       {posts.map((o, index) => (
         <PostItem key={index} post={o} />
       ))}

--- a/src/components/Posts/PostList.tsx
+++ b/src/components/Posts/PostList.tsx
@@ -5,6 +5,9 @@ import axios from "axios";
 export type Post = {
   displayName: string;
   imagePath?: string;
+  isLikedByCurrentUser: boolean;
+  numberOfLikes: number;
+  postId: number;
   textContent: string;
   timestamp: string;
   username: string;
@@ -15,7 +18,11 @@ const Timeline = () => {
 
   useEffect(() => {
     const fetchPosts = async () => {
-      const result = await axios.get("http://localhost:3001/api/posts");
+      const result = await axios.get("http://localhost:3001/api/posts", {
+        params: {
+          userId: 1,
+        },
+      });
       setPosts(result.data as Post[]);
     };
     fetchPosts();
@@ -23,8 +30,9 @@ const Timeline = () => {
 
   return (
     <>
+      {console.log(posts)}
       {posts.map((o, index) => (
-        <PostItem post={o} key={index} />
+        <PostItem key={index} post={o} />
       ))}
     </>
   );

--- a/src/context/PostContext.tsx
+++ b/src/context/PostContext.tsx
@@ -1,0 +1,32 @@
+import { createContext, useContext, useState } from "react";
+import { Post } from "../components/Posts/PostList";
+
+type PostContextType = {
+  posts: Post[];
+  setPosts: (posts: Post[]) => void;
+  updatePost: (updatedPost: Post) => void;
+};
+
+const PostContext = createContext<PostContextType | null>(null);
+
+export const PostContextProvider = ({ children }: any) => {
+  const [posts, setPosts] = useState<Post[]>([]);
+
+  const updatePost = (updatedPost: Post) => {
+    const newPosts = posts.map((o) => {
+      if (o.postId === updatedPost.postId) {
+        return updatedPost;
+      }
+      return o;
+    });
+    setPosts(newPosts);
+  };
+
+  return (
+    <PostContext.Provider value={{ posts, setPosts, updatePost }}>
+      {children}
+    </PostContext.Provider>
+  );
+};
+
+export const usePostContext = () => useContext(PostContext) as PostContextType;


### PR DESCRIPTION
Resolves #27. This PR adds the ability for users to like and unlike posts.

- Added `PostContext`, which is a context where the `posts` state is stored
  - Exports `PostContextProvider`, which is the provider that needs to wrap children who want to access the posts
  - Exports `usePostContext`, which is a custom hook that you can use to access the `posts` state and the state setters