### PR TITLE
T33: Removed messages route from navbar and from the list of protected routes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -53,22 +53,22 @@ function App() {
   }
 
   return (
-<PostContextProvider>
-    <div className="App" style={{ display: "flex" }}>
-      <NavBar />
-      <Routes>
-        <Route path="/" element={<ProtectedRoute component={Timeline} />} />
-        <Route
+    <PostContextProvider>
+      <div className="App" style={{ display: "flex" }}>
+        <NavBar />
+        <Routes>
+          <Route path="/" element={<ProtectedRoute component={Timeline} />} />
+          {/* <Route
           path="/messages"
           element={<ProtectedRoute component={Messages} />}
-        />
-        <Route
-          path="/profile"
-          element={<ProtectedRoute component={Profile} />}
-        />
-      </Routes>
-    </div>
-</PostContextProvider>
+        /> */}
+          <Route
+            path="/profile"
+            element={<ProtectedRoute component={Profile} />}
+          />
+        </Routes>
+      </div>
+    </PostContextProvider>
   );
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,6 @@ import { useEffect } from "react";
 import Register from "./pages/Register";
 import { ProtectedRoute } from "./components/Auth/ProtectedRoute";
 import PageLoader from "./pages/PageLoader";
-// import Messages from "./pages/Messages";
 import Profile from "./pages/Profile";
 import { useUserContext } from "./context/UserContext";
 import "./App.css";
@@ -58,10 +57,6 @@ function App() {
         <NavBar />
         <Routes>
           <Route path="/" element={<ProtectedRoute component={Timeline} />} />
-          {/* <Route
-          path="/messages"
-          element={<ProtectedRoute component={Messages} />}
-        /> */}
           <Route
             path="/profile"
             element={<ProtectedRoute component={Profile} />}

--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,7 @@ import { useEffect } from "react";
 import Register from "./pages/Register";
 import { ProtectedRoute } from "./components/Auth/ProtectedRoute";
 import PageLoader from "./pages/PageLoader";
-import Messages from "./pages/Messages";
+// import Messages from "./pages/Messages";
 import Profile from "./pages/Profile";
 import { useUserContext } from "./context/UserContext";
 import "./App.css";

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -39,11 +39,6 @@ const navItems = [
     label: "Home",
     route: "/",
   },
-  // {
-  //   icon: <MailIcon />,
-  //   label: "Messages",
-  //   route: "/messages",
-  // },
   {
     icon: <AccountCircleIcon />,
     label: "Profile",

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -1,5 +1,5 @@
 import HomeIcon from "@mui/icons-material/Home";
-import MailIcon from "@mui/icons-material/Mail";
+// import MailIcon from "@mui/icons-material/Mail";
 import AccountCircleIcon from "@mui/icons-material/AccountCircle";
 import { Avatar, Button, List, Stack, Toolbar } from "@mui/material";
 import { Drawer } from "@mui/material";
@@ -39,11 +39,11 @@ const navItems = [
     label: "Home",
     route: "/",
   },
-  {
-    icon: <MailIcon />,
-    label: "Messages",
-    route: "/messages",
-  },
+  // {
+  //   icon: <MailIcon />,
+  //   label: "Messages",
+  //   route: "/messages",
+  // },
   {
     icon: <AccountCircleIcon />,
     label: "Profile",

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -1,5 +1,4 @@
 import HomeIcon from "@mui/icons-material/Home";
-// import MailIcon from "@mui/icons-material/Mail";
 import AccountCircleIcon from "@mui/icons-material/AccountCircle";
 import { Avatar, Button, List, Stack, Toolbar } from "@mui/material";
 import { Drawer } from "@mui/material";


### PR DESCRIPTION
Removed messages protected route from `Navbar.tsx` and `App.js`. I left the `Messages.tsx` page alone as this will still be used in the standalone messages ticket, and I didn't find a reason to modify that file.