### PR TITLE
T29: Fix visual bug with post action numbers

### DIFF
--- a/src/components/Posts/PostItem.tsx
+++ b/src/components/Posts/PostItem.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, Stack, Typography } from "@mui/material";
+import { Button, Card, CardContent, Stack, Typography } from "@mui/material";
 import Avatar from "@mui/material/Avatar/Avatar";
 import CardHeader from "@mui/material/CardHeader/CardHeader";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
@@ -21,9 +21,6 @@ const styles = {
   },
   cardActions: {
     width: "100%",
-  },
-  actionNumbers: {
-    paddingLeft: 1,
   },
 };
 
@@ -97,33 +94,25 @@ const PostItem = ({ post }: PostProps) => {
           justifyContent="space-between"
           sx={styles.cardActions}
         >
-          <IconButton
+          <Button
             onClick={() => {
               post.isLikedByCurrentUser
                 ? unlikePost(post.postId, user.userId)
                 : likePost(post.postId, user.userId);
             }}
+            startIcon={
+              post.isLikedByCurrentUser ? (
+                <FavoriteOutlinedIcon />
+              ) : (
+                <FavoriteBorderOutlinedIcon />
+              )
+            }
           >
-            {post.isLikedByCurrentUser ? (
-              <FavoriteOutlinedIcon />
-            ) : (
-              <FavoriteBorderOutlinedIcon />
-            )}
-            <Typography sx={styles.actionNumbers}>
-              {post.numberOfLikes}
-            </Typography>
-          </IconButton>
-          <IconButton>
-            <AddCommentOutlinedIcon />
-            <Typography sx={styles.actionNumbers}>1</Typography>
-          </IconButton>
-          <IconButton>
-            <RepeatOutlinedIcon />
-            <Typography sx={styles.actionNumbers}>1</Typography>
-          </IconButton>
-          <IconButton>
-            <ShareOutlinedIcon />
-          </IconButton>
+            {post.numberOfLikes}
+          </Button>
+          <Button startIcon={<AddCommentOutlinedIcon />}>1</Button>
+          <Button startIcon={<RepeatOutlinedIcon />}>1</Button>
+          <Button startIcon={<ShareOutlinedIcon />} />
         </Stack>
       </CardActions>
     </Card>


### PR DESCRIPTION
**Context:**

Closes #29. There is a bug with the post action numbers that causes them to shift when the numbers on other nearby buttons change. I believe the cause of this was that we had both the svg icon and the number text inside the `IconButton`

**Solution:**

After looking at the MUI docs, if we want to display an icon beside text, we should be using the `startIcon` prop on their `Button` component
- I kept the color of the buttons the default color, which is the green we use in our theme. It'd be good if we could meet to pick out colors for our buttons later