### PR TITLE
T52: Icon Colours

### DIFF
--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -20,7 +20,7 @@ const styles = {
       width: drawerWidth,
     },
   },
-  postButton: { borderRadius: 10, margin: 2 },
+  postButton: { margin: 2 },
   stack: {
     marginBottom: "auto",
     width: "100%",

--- a/src/components/Posts/ComposePost.tsx
+++ b/src/components/Posts/ComposePost.tsx
@@ -35,15 +35,6 @@ const styles = {
     justifyContent: "space-between",
     marginTop: 1,
   },
-  postButton: {
-    "&.Mui-disabled": {
-      backgroundColor: "primary.light",
-      color: "white",
-    },
-    borderRadius: 5,
-    height: 35,
-    weight: 35,
-  },
 };
 
 const ComposePost = ({ placeholder, minRows }: ComposePostProps) => {
@@ -90,21 +81,19 @@ const ComposePost = ({ placeholder, minRows }: ComposePostProps) => {
             sx={styles.textField}
             value={postTextContent}
             variant="standard"
-            InputProps={{ disableUnderline: true }}
           />
           <Box sx={styles.postActions}>
             <Stack direction="row">
-              <IconButton size="small" color="primary">
+              <IconButton size="small">
                 <AddPhotoAlternateOutlinedIcon />
               </IconButton>
-              <IconButton size="small" color="primary">
+              <IconButton size="small">
                 <EmojiEmotionsOutlinedIcon />
               </IconButton>
             </Stack>
             <Button
               disabled={!postTextContent.trim()}
               size="small"
-              sx={styles.postButton}
               type="submit"
               variant="contained"
             >

--- a/src/components/Posts/ComposePost.tsx
+++ b/src/components/Posts/ComposePost.tsx
@@ -28,24 +28,21 @@ const styles = {
     justifyContent: "space-between",
     marginTop: 1,
   },
-  postButton: { borderRadius: 5 },
+  postButton: {
+    "&.Mui-disabled": {
+      backgroundColor: "primary.light",
+      color: "white",
+    },
+    borderRadius: 5,
+    height: 35,
+    weight: 35,
+  },
 };
 
 const ComposePost = ({ placeholder }: ComposePostProps) => {
   const [postTextContent, setPostTextContent] = useState("");
   const user = useAppSelector((state) => state.user);
   const dispatch = useAppDispatch();
-  const buttonStyle = {
-    postButton: {
-      "&.Mui-disabled": {
-        backgroundColor: "primary.light",
-        color: "white",
-      },
-      borderRadius: 5,
-      height: 35,
-      weight: 35,
-    },
-  };
 
   const onSubmit = async (e: React.SyntheticEvent) => {
     e.preventDefault();
@@ -98,7 +95,7 @@ const ComposePost = ({ placeholder }: ComposePostProps) => {
             <Button
               disabled={!postTextContent.trim()}
               size="small"
-              sx={buttonStyle.postButton}
+              sx={styles.postButton}
               type="submit"
               variant="contained"
             >

--- a/src/components/Posts/ComposePost.tsx
+++ b/src/components/Posts/ComposePost.tsx
@@ -35,6 +35,17 @@ const ComposePost = ({ placeholder }: ComposePostProps) => {
   const [postTextContent, setPostTextContent] = useState("");
   const user = useAppSelector((state) => state.user);
   const dispatch = useAppDispatch();
+  const buttonStyle = {
+    postButton: {
+      "&.Mui-disabled": {
+        backgroundColor: "primary.light",
+        color: "white",
+      },
+      borderRadius: 5,
+      height: 35,
+      weight: 35,
+    },
+  };
 
   const onSubmit = async (e: React.SyntheticEvent) => {
     e.preventDefault();
@@ -87,7 +98,7 @@ const ComposePost = ({ placeholder }: ComposePostProps) => {
             <Button
               disabled={!postTextContent.trim()}
               size="small"
-              sx={styles.postButton}
+              sx={buttonStyle.postButton}
               type="submit"
               variant="contained"
             >

--- a/src/components/Posts/ComposePost.tsx
+++ b/src/components/Posts/ComposePost.tsx
@@ -88,10 +88,10 @@ const ComposePost = ({ placeholder }: ComposePostProps) => {
           />
           <Box sx={styles.postActions}>
             <Stack direction="row">
-              <IconButton size="small">
+              <IconButton size="small" color="primary">
                 <AddPhotoAlternateOutlinedIcon />
               </IconButton>
-              <IconButton size="small">
+              <IconButton size="small" color="primary">
                 <EmojiEmotionsOutlinedIcon />
               </IconButton>
             </Stack>

--- a/src/components/Posts/ComposeReply.tsx
+++ b/src/components/Posts/ComposeReply.tsx
@@ -33,6 +33,10 @@ const styles = {
     paddingBottom: 2,
   },
   postButton: {
+    "&.Mui-disabled": {
+      backgroundColor: "primary.light",
+      color: "white",
+    },
     borderRadius: 5,
     height: 35,
     weight: 35,
@@ -51,17 +55,6 @@ const ComposeReply = ({ placeholder }: ComposeReplyProps) => {
   const user = useAppSelector((state) => state.user);
   const post = useAppSelector((state) => state.post);
   const dispatch = useAppDispatch();
-  const buttonStyle = {
-    postButton: {
-      "&.Mui-disabled": {
-        backgroundColor: "primary.light",
-        color: "white",
-      },
-      borderRadius: 5,
-      height: 35,
-      weight: 35,
-    },
-  };
 
   const onSubmit = async (e: React.SyntheticEvent) => {
     e.preventDefault();
@@ -112,7 +105,7 @@ const ComposeReply = ({ placeholder }: ComposeReplyProps) => {
             <Button
               disabled={!postTextContent.trim()}
               size="small"
-              sx={buttonStyle.postButton}
+              sx={styles.postButton}
               type="submit"
               variant="contained"
             >

--- a/src/components/Posts/ComposeReply.tsx
+++ b/src/components/Posts/ComposeReply.tsx
@@ -123,10 +123,10 @@ const ComposeReply = ({ placeholder }: ComposeReplyProps) => {
         {focusReply && (
           <Box sx={styles.postActions}>
             <Stack direction="row">
-              <IconButton size="small">
+              <IconButton size="small" color="primary">
                 <AddPhotoAlternateOutlinedIcon />
               </IconButton>
-              <IconButton size="small">
+              <IconButton size="small" color="primary">
                 <EmojiEmotionsOutlinedIcon />
               </IconButton>
             </Stack>

--- a/src/components/Posts/ComposeReply.tsx
+++ b/src/components/Posts/ComposeReply.tsx
@@ -26,6 +26,7 @@ const styles = {
   textFieldContainer: {
     width: "100%",
     display: "flex",
+    alignItems: "center",
   },
   textField: { paddingBottom: 2, paddingRight: 1 },
   postActions: {
@@ -33,13 +34,7 @@ const styles = {
     paddingBottom: 2,
   },
   postButton: {
-    "&.Mui-disabled": {
-      backgroundColor: "primary.light",
-      color: "white",
-    },
-    borderRadius: 5,
-    height: 35,
-    weight: 35,
+    minHeight: "34px",
   },
   topContainer: {
     display: "flex",
@@ -51,7 +46,7 @@ const styles = {
 
 const ComposeReply = ({ placeholder }: ComposeReplyProps) => {
   const [postTextContent, setPostTextContent] = useState("");
-  const [focusReply, setFocusReply] = useState(false);
+  const [focusReply, setFocusReply] = useState(true);
   const user = useAppSelector((state) => state.user);
   const post = useAppSelector((state) => state.post);
   const dispatch = useAppDispatch();
@@ -100,7 +95,6 @@ const ComposeReply = ({ placeholder }: ComposeReplyProps) => {
               value={postTextContent}
               variant="standard"
               onFocus={() => setFocusReply(true)}
-              InputProps={{ disableUnderline: true }}
             />
             <Button
               disabled={!postTextContent.trim()}
@@ -116,10 +110,10 @@ const ComposeReply = ({ placeholder }: ComposeReplyProps) => {
         {focusReply && (
           <Box sx={styles.postActions}>
             <Stack direction="row">
-              <IconButton size="small" color="primary">
+              <IconButton size="small">
                 <AddPhotoAlternateOutlinedIcon />
               </IconButton>
-              <IconButton size="small" color="primary">
+              <IconButton size="small">
                 <EmojiEmotionsOutlinedIcon />
               </IconButton>
             </Stack>

--- a/src/components/Posts/ComposeReply.tsx
+++ b/src/components/Posts/ComposeReply.tsx
@@ -51,6 +51,17 @@ const ComposeReply = ({ placeholder }: ComposeReplyProps) => {
   const user = useAppSelector((state) => state.user);
   const post = useAppSelector((state) => state.post);
   const dispatch = useAppDispatch();
+  const buttonStyle = {
+    postButton: {
+      "&.Mui-disabled": {
+        backgroundColor: "primary.light",
+        color: "white",
+      },
+      borderRadius: 5,
+      height: 35,
+      weight: 35,
+    },
+  };
 
   const onSubmit = async (e: React.SyntheticEvent) => {
     e.preventDefault();
@@ -101,7 +112,7 @@ const ComposeReply = ({ placeholder }: ComposeReplyProps) => {
             <Button
               disabled={!postTextContent.trim()}
               size="small"
-              sx={styles.postButton}
+              sx={buttonStyle.postButton}
               type="submit"
               variant="contained"
             >

--- a/src/components/Posts/ExpandedPostItem.tsx
+++ b/src/components/Posts/ExpandedPostItem.tsx
@@ -99,6 +99,20 @@ const ExpandedPostItem = () => {
   const user = useAppSelector((state) => state.user);
   const post = useAppSelector((state) => state.post);
   const urlParams = useParams();
+  const iconStyles = {
+    likeIcon: {
+      color: post.isLikedByCurrentUser ? "primary.main" : "gray.main",
+      "&:hover": {
+        color: "primary.main",
+      },
+    },
+    tempIcon: {
+      color: "gray.main",
+      "&:hover": {
+        color: "primary.main",
+      },
+    },
+  };
 
   useEffect(() => {
     const updatedExpandedPost = async () => {
@@ -209,6 +223,7 @@ const ExpandedPostItem = () => {
                 ? unlikePost(post.postId, user.userId)
                 : likePost(post.postId, user.userId);
             }}
+            sx={iconStyles.likeIcon}
           >
             {post.isLikedByCurrentUser ? (
               <FavoriteOutlinedIcon />
@@ -216,13 +231,13 @@ const ExpandedPostItem = () => {
               <FavoriteBorderOutlinedIcon />
             )}
           </IconButton>
-          <IconButton>
+          <IconButton sx={iconStyles.tempIcon}>
             <AddCommentOutlinedIcon />
           </IconButton>
-          <IconButton>
+          <IconButton sx={iconStyles.tempIcon}>
             <RepeatOutlinedIcon />
           </IconButton>
-          <IconButton>
+          <IconButton sx={iconStyles.tempIcon}>
             <ShareOutlinedIcon />
           </IconButton>
         </Stack>

--- a/src/components/Posts/ExpandedPostItem.tsx
+++ b/src/components/Posts/ExpandedPostItem.tsx
@@ -27,9 +27,31 @@ import {
   updateExpandedPost,
 } from "../../state/slices/expandedPostSlice";
 import { useEffect } from "react";
-import { Post } from "../../state/slices/postsSlice";
 
-const styles = (post: Post) => ({
+const styles = {
+  actionButton: {
+    fontSize: 14.5,
+    padding: 0,
+    color: "black",
+    textTransform: "none",
+    fontWeight: "bold",
+    marginRight: 2,
+    display: "flex",
+  },
+  actionData: {
+    display: "flex",
+    paddingTop: 1,
+    paddingBottom: 1,
+    paddingLeft: 1,
+  },
+  actionTitles: {
+    paddingLeft: 0.5,
+    fontSize: 14.5,
+  },
+  backButton: {
+    backgroundColor: "transparent",
+    paddingRight: 10,
+  },
   card: {
     padding: 0,
     boxShadow: "none",
@@ -38,82 +60,33 @@ const styles = (post: Post) => ({
     width: "100%",
   },
   cardContent: { width: 400 },
-  actionButton: {
-    border: "none",
-    fontSize: 14.5,
-    padding: 0,
-    backgroundColor: "white",
-    color: "black",
-    textTransform: "none",
+  headerTitle: {
     fontWeight: "bold",
-    marginRight: 2,
-    display: "flex",
-    alignItems: "center",
-    "&:hover": {
-      backgroundColor: "white",
-    },
   },
-  actionData: {
-    display: "flex",
-    paddingTop: 1,
-    paddingBottom: 1,
-    paddingLeft: 1,
-  },
-  timestampBox: {
-    display: "flex",
-    paddingTop: 1,
-    paddingBottom: 1,
-  },
-  actionTitles: {
-    paddingLeft: 0.5,
-    fontSize: 14.5,
-  },
-  actionNumbers: {
-    fontWeight: "bold",
-    fontSize: 14.5,
-    marginLeft: "auto",
+  likedIcon: {
+    color: "primary.main",
   },
   timestamp: {
     paddingLeft: 2,
     fontSize: 14.5,
     color: "#a4a8ab",
   },
-  actionArea: {
-    "&:hover $focusHighlight": {
-      opacity: 0,
-    },
+  timestampBox: {
+    display: "flex",
+    paddingTop: 1,
+    paddingBottom: 1,
   },
   topHeader: {
     display: "flex",
     alignItems: "center",
   },
-  backButton: {
-    backgroundColor: "transparent",
-    paddingRight: 10,
-  },
-  headerTitle: {
-    fontWeight: "bold",
-  },
-  likeIcon: {
-    color: post.isLikedByCurrentUser ? "primary.main" : "gray.main",
-    "&:hover": {
-      color: "primary.main",
-    },
-  },
-  tempIcon: {
-    color: "gray.main",
-    "&:hover": {
-      color: "primary.main",
-    },
-  },
-});
+};
 
 const ExpandedPostItem = () => {
   const dispatch = useAppDispatch();
   const user = useAppSelector((state) => state.user);
   const post = useAppSelector((state) => state.post);
   const urlParams = useParams();
-  const expandedPostStyles = styles(post);
 
   useEffect(() => {
     const updatedExpandedPost = async () => {
@@ -166,20 +139,17 @@ const ExpandedPostItem = () => {
   const navigate = useNavigate();
 
   return (
-    <Card sx={expandedPostStyles.card}>
-      <Box style={expandedPostStyles.topHeader}>
-        <IconButton
-          style={expandedPostStyles.backButton}
-          onClick={() => navigate(-1)}
-        >
+    <Card sx={styles.card}>
+      <Box style={styles.topHeader}>
+        <IconButton style={styles.backButton} onClick={() => navigate(-1)}>
           <KeyboardBackspaceIcon color="secondary" />
         </IconButton>
-        <Typography style={expandedPostStyles.headerTitle}>Post</Typography>
+        <Typography style={styles.headerTitle}>Post</Typography>
       </Box>
       <CardHeader
         avatar={<Avatar>CK</Avatar>}
         action={
-          <IconButton sx={expandedPostStyles.tempIcon}>
+          <IconButton>
             <MoreVertIcon />
           </IconButton>
         }
@@ -196,23 +166,22 @@ const ExpandedPostItem = () => {
           image={post.imagePath}
         />
       )}
-      <Box sx={expandedPostStyles.timestampBox}>
-        <Typography component={"span"} sx={expandedPostStyles.timestamp}>
+      <Box sx={styles.timestampBox}>
+        <Typography component={"span"} sx={styles.timestamp}>
           {post.timestamp}
         </Typography>
       </Box>
       <Divider variant="middle" />
-      <Box sx={expandedPostStyles.actionData}>
-        <Button sx={expandedPostStyles.actionButton}>
+      <Box sx={styles.actionData}>
+        <Button sx={styles.actionButton}>
           {post.numberOfLikes}
-          <Typography sx={expandedPostStyles.actionTitles}>Likes</Typography>
+          <Typography sx={styles.actionTitles}>Likes</Typography>
         </Button>
-        <Button component={"span"} sx={expandedPostStyles.actionButton}>
-          1
-          <Typography sx={expandedPostStyles.actionTitles}>Comments</Typography>
+        <Button component={"span"} sx={styles.actionButton}>
+          1<Typography sx={styles.actionTitles}>Comments</Typography>
         </Button>
-        <Button component={"span"} sx={expandedPostStyles.actionButton}>
-          1<Typography sx={expandedPostStyles.actionTitles}>Reposts</Typography>
+        <Button component={"span"} sx={styles.actionButton}>
+          1<Typography sx={styles.actionTitles}>Reposts</Typography>
         </Button>
       </Box>
       <Divider variant="middle" />
@@ -220,7 +189,7 @@ const ExpandedPostItem = () => {
         <Stack
           direction="row"
           justifyContent="space-between"
-          sx={expandedPostStyles.cardActions}
+          sx={styles.cardActions}
         >
           <IconButton
             onClick={() => {
@@ -228,7 +197,7 @@ const ExpandedPostItem = () => {
                 ? unlikePost(post.postId, user.userId)
                 : likePost(post.postId, user.userId);
             }}
-            sx={expandedPostStyles.likeIcon}
+            sx={post.isLikedByCurrentUser ? styles.likedIcon : undefined}
           >
             {post.isLikedByCurrentUser ? (
               <FavoriteOutlinedIcon />
@@ -236,13 +205,13 @@ const ExpandedPostItem = () => {
               <FavoriteBorderOutlinedIcon />
             )}
           </IconButton>
-          <IconButton sx={expandedPostStyles.tempIcon}>
+          <IconButton>
             <AddCommentOutlinedIcon />
           </IconButton>
-          <IconButton sx={expandedPostStyles.tempIcon}>
+          <IconButton>
             <RepeatOutlinedIcon />
           </IconButton>
-          <IconButton sx={expandedPostStyles.tempIcon}>
+          <IconButton>
             <ShareOutlinedIcon />
           </IconButton>
         </Stack>

--- a/src/components/Posts/ExpandedPostItem.tsx
+++ b/src/components/Posts/ExpandedPostItem.tsx
@@ -105,6 +105,9 @@ const styles = (post: Post) => ({
       color: "primary.main",
     },
   },
+  vertIcon: {
+    color: "primary.main",
+  },
 });
 
 const ExpandedPostItem = () => {
@@ -112,7 +115,7 @@ const ExpandedPostItem = () => {
   const user = useAppSelector((state) => state.user);
   const post = useAppSelector((state) => state.post);
   const urlParams = useParams();
-  const ePostStyles = styles(post);
+  const expandedPostStyles = styles(post);
 
   useEffect(() => {
     const updatedExpandedPost = async () => {
@@ -165,17 +168,20 @@ const ExpandedPostItem = () => {
   const navigate = useNavigate();
 
   return (
-    <Card sx={ePostStyles.card}>
-      <Box style={ePostStyles.topHeader}>
-        <IconButton style={ePostStyles.backButton} onClick={() => navigate(-1)}>
+    <Card sx={expandedPostStyles.card}>
+      <Box style={expandedPostStyles.topHeader}>
+        <IconButton
+          style={expandedPostStyles.backButton}
+          onClick={() => navigate(-1)}
+        >
           <KeyboardBackspaceIcon color="secondary" />
         </IconButton>
-        <Typography style={ePostStyles.headerTitle}>Post</Typography>
+        <Typography style={expandedPostStyles.headerTitle}>Post</Typography>
       </Box>
       <CardHeader
         avatar={<Avatar>CK</Avatar>}
         action={
-          <IconButton>
+          <IconButton sx={expandedPostStyles.vertIcon}>
             <MoreVertIcon />
           </IconButton>
         }
@@ -192,22 +198,23 @@ const ExpandedPostItem = () => {
           image={post.imagePath}
         />
       )}
-      <Box sx={ePostStyles.timestampBox}>
-        <Typography component={"span"} sx={ePostStyles.timestamp}>
+      <Box sx={expandedPostStyles.timestampBox}>
+        <Typography component={"span"} sx={expandedPostStyles.timestamp}>
           {post.timestamp}
         </Typography>
       </Box>
       <Divider variant="middle" />
-      <Box sx={ePostStyles.actionData}>
-        <Button sx={ePostStyles.actionButton}>
+      <Box sx={expandedPostStyles.actionData}>
+        <Button sx={expandedPostStyles.actionButton}>
           {post.numberOfLikes}
-          <Typography sx={ePostStyles.actionTitles}>Likes</Typography>
+          <Typography sx={expandedPostStyles.actionTitles}>Likes</Typography>
         </Button>
-        <Button component={"span"} sx={ePostStyles.actionButton}>
-          1<Typography sx={ePostStyles.actionTitles}>Comments</Typography>
+        <Button component={"span"} sx={expandedPostStyles.actionButton}>
+          1
+          <Typography sx={expandedPostStyles.actionTitles}>Comments</Typography>
         </Button>
-        <Button component={"span"} sx={ePostStyles.actionButton}>
-          1<Typography sx={ePostStyles.actionTitles}>Reposts</Typography>
+        <Button component={"span"} sx={expandedPostStyles.actionButton}>
+          1<Typography sx={expandedPostStyles.actionTitles}>Reposts</Typography>
         </Button>
       </Box>
       <Divider variant="middle" />
@@ -215,7 +222,7 @@ const ExpandedPostItem = () => {
         <Stack
           direction="row"
           justifyContent="space-between"
-          sx={ePostStyles.cardActions}
+          sx={expandedPostStyles.cardActions}
         >
           <IconButton
             onClick={() => {
@@ -223,7 +230,7 @@ const ExpandedPostItem = () => {
                 ? unlikePost(post.postId, user.userId)
                 : likePost(post.postId, user.userId);
             }}
-            sx={ePostStyles.likeIcon}
+            sx={expandedPostStyles.likeIcon}
           >
             {post.isLikedByCurrentUser ? (
               <FavoriteOutlinedIcon />
@@ -231,13 +238,13 @@ const ExpandedPostItem = () => {
               <FavoriteBorderOutlinedIcon />
             )}
           </IconButton>
-          <IconButton sx={ePostStyles.tempIcon}>
+          <IconButton sx={expandedPostStyles.tempIcon}>
             <AddCommentOutlinedIcon />
           </IconButton>
-          <IconButton sx={ePostStyles.tempIcon}>
+          <IconButton sx={expandedPostStyles.tempIcon}>
             <RepeatOutlinedIcon />
           </IconButton>
-          <IconButton sx={ePostStyles.tempIcon}>
+          <IconButton sx={expandedPostStyles.tempIcon}>
             <ShareOutlinedIcon />
           </IconButton>
         </Stack>

--- a/src/components/Posts/ExpandedPostItem.tsx
+++ b/src/components/Posts/ExpandedPostItem.tsx
@@ -105,9 +105,6 @@ const styles = (post: Post) => ({
       color: "primary.main",
     },
   },
-  vertIcon: {
-    color: "primary.main",
-  },
 });
 
 const ExpandedPostItem = () => {
@@ -181,7 +178,7 @@ const ExpandedPostItem = () => {
       <CardHeader
         avatar={<Avatar>CK</Avatar>}
         action={
-          <IconButton sx={expandedPostStyles.vertIcon}>
+          <IconButton sx={expandedPostStyles.tempIcon}>
             <MoreVertIcon />
           </IconButton>
         }

--- a/src/components/Posts/ExpandedPostItem.tsx
+++ b/src/components/Posts/ExpandedPostItem.tsx
@@ -27,8 +27,9 @@ import {
   updateExpandedPost,
 } from "../../state/slices/expandedPostSlice";
 import { useEffect } from "react";
+import { Post } from "../../state/slices/postsSlice";
 
-const styles = {
+const styles = (post: Post) => ({
   card: {
     padding: 0,
     boxShadow: "none",
@@ -92,27 +93,26 @@ const styles = {
   headerTitle: {
     fontWeight: "bold",
   },
-};
+  likeIcon: {
+    color: post.isLikedByCurrentUser ? "primary.main" : "gray.main",
+    "&:hover": {
+      color: "primary.main",
+    },
+  },
+  tempIcon: {
+    color: "gray.main",
+    "&:hover": {
+      color: "primary.main",
+    },
+  },
+});
 
 const ExpandedPostItem = () => {
   const dispatch = useAppDispatch();
   const user = useAppSelector((state) => state.user);
   const post = useAppSelector((state) => state.post);
   const urlParams = useParams();
-  const iconStyles = {
-    likeIcon: {
-      color: post.isLikedByCurrentUser ? "primary.main" : "gray.main",
-      "&:hover": {
-        color: "primary.main",
-      },
-    },
-    tempIcon: {
-      color: "gray.main",
-      "&:hover": {
-        color: "primary.main",
-      },
-    },
-  };
+  const ePostStyles = styles(post);
 
   useEffect(() => {
     const updatedExpandedPost = async () => {
@@ -165,12 +165,12 @@ const ExpandedPostItem = () => {
   const navigate = useNavigate();
 
   return (
-    <Card sx={styles.card}>
-      <Box style={styles.topHeader}>
-        <IconButton style={styles.backButton} onClick={() => navigate(-1)}>
+    <Card sx={ePostStyles.card}>
+      <Box style={ePostStyles.topHeader}>
+        <IconButton style={ePostStyles.backButton} onClick={() => navigate(-1)}>
           <KeyboardBackspaceIcon color="secondary" />
         </IconButton>
-        <Typography style={styles.headerTitle}>Post</Typography>
+        <Typography style={ePostStyles.headerTitle}>Post</Typography>
       </Box>
       <CardHeader
         avatar={<Avatar>CK</Avatar>}
@@ -192,22 +192,22 @@ const ExpandedPostItem = () => {
           image={post.imagePath}
         />
       )}
-      <Box sx={styles.timestampBox}>
-        <Typography component={"span"} sx={styles.timestamp}>
+      <Box sx={ePostStyles.timestampBox}>
+        <Typography component={"span"} sx={ePostStyles.timestamp}>
           {post.timestamp}
         </Typography>
       </Box>
       <Divider variant="middle" />
-      <Box sx={styles.actionData}>
-        <Button sx={styles.actionButton}>
+      <Box sx={ePostStyles.actionData}>
+        <Button sx={ePostStyles.actionButton}>
           {post.numberOfLikes}
-          <Typography sx={styles.actionTitles}>Likes</Typography>
+          <Typography sx={ePostStyles.actionTitles}>Likes</Typography>
         </Button>
-        <Button component={"span"} sx={styles.actionButton}>
-          1<Typography sx={styles.actionTitles}>Comments</Typography>
+        <Button component={"span"} sx={ePostStyles.actionButton}>
+          1<Typography sx={ePostStyles.actionTitles}>Comments</Typography>
         </Button>
-        <Button component={"span"} sx={styles.actionButton}>
-          1<Typography sx={styles.actionTitles}>Reposts</Typography>
+        <Button component={"span"} sx={ePostStyles.actionButton}>
+          1<Typography sx={ePostStyles.actionTitles}>Reposts</Typography>
         </Button>
       </Box>
       <Divider variant="middle" />
@@ -215,7 +215,7 @@ const ExpandedPostItem = () => {
         <Stack
           direction="row"
           justifyContent="space-between"
-          sx={styles.cardActions}
+          sx={ePostStyles.cardActions}
         >
           <IconButton
             onClick={() => {
@@ -223,7 +223,7 @@ const ExpandedPostItem = () => {
                 ? unlikePost(post.postId, user.userId)
                 : likePost(post.postId, user.userId);
             }}
-            sx={iconStyles.likeIcon}
+            sx={ePostStyles.likeIcon}
           >
             {post.isLikedByCurrentUser ? (
               <FavoriteOutlinedIcon />
@@ -231,13 +231,13 @@ const ExpandedPostItem = () => {
               <FavoriteBorderOutlinedIcon />
             )}
           </IconButton>
-          <IconButton sx={iconStyles.tempIcon}>
+          <IconButton sx={ePostStyles.tempIcon}>
             <AddCommentOutlinedIcon />
           </IconButton>
-          <IconButton sx={iconStyles.tempIcon}>
+          <IconButton sx={ePostStyles.tempIcon}>
             <RepeatOutlinedIcon />
           </IconButton>
-          <IconButton sx={iconStyles.tempIcon}>
+          <IconButton sx={ePostStyles.tempIcon}>
             <ShareOutlinedIcon />
           </IconButton>
         </Stack>

--- a/src/components/Posts/PostItem.tsx
+++ b/src/components/Posts/PostItem.tsx
@@ -27,7 +27,8 @@ import { setExpandedPost } from "../../state/slices/expandedPostSlice";
 type PostProps = {
   post: Post;
 };
-const styles = (post: Post) => ({
+
+const styles = {
   card: {
     boxShadow: "none",
   },
@@ -35,25 +36,20 @@ const styles = (post: Post) => ({
     width: "100%",
   },
   cardContent: { width: 400 },
-  likeIcon: {
-    color: post.isLikedByCurrentUser ? "primary.main" : "gray.main",
-    "&:hover": {
-      color: "primary.main",
-    },
+  coloredButton: {
+    color: "primary.main",
   },
-  tempIcon: {
+  defaultButton: {
     color: "gray.main",
     "&:hover": {
       color: "primary.main",
     },
   },
-});
+};
 
 const PostItem = ({ post }: PostProps) => {
   const dispatch = useAppDispatch();
   const user = useAppSelector((state) => state.user);
-  const postStyles = styles(post);
-
   const likePost = async (postId: number, userId?: number) => {
     await axios.post("http://localhost:3001/api/posts/likePost", {
       postId,
@@ -94,11 +90,11 @@ const PostItem = ({ post }: PostProps) => {
   };
 
   return (
-    <Card sx={postStyles.card}>
+    <Card sx={styles.card}>
       <CardHeader
         avatar={<Avatar>CK</Avatar>}
         action={
-          <IconButton sx={postStyles.tempIcon}>
+          <IconButton>
             <MoreVertIcon />
           </IconButton>
         }
@@ -121,7 +117,7 @@ const PostItem = ({ post }: PostProps) => {
         <Stack
           direction="row"
           justifyContent="space-between"
-          sx={postStyles.cardActions}
+          sx={styles.cardActions}
         >
           <Button
             onClick={() => {
@@ -136,20 +132,24 @@ const PostItem = ({ post }: PostProps) => {
                 <FavoriteBorderOutlinedIcon />
               )
             }
-            sx={postStyles.likeIcon}
+            sx={
+              post.isLikedByCurrentUser
+                ? styles.coloredButton
+                : styles.defaultButton
+            }
           >
             {post.numberOfLikes}
           </Button>
           <Button
             startIcon={<AddCommentOutlinedIcon />}
-            sx={postStyles.tempIcon}
+            sx={styles.defaultButton}
           >
             1
           </Button>
-          <Button startIcon={<RepeatOutlinedIcon />} sx={postStyles.tempIcon}>
+          <Button startIcon={<RepeatOutlinedIcon />} sx={styles.defaultButton}>
             1
           </Button>
-          <Button startIcon={<ShareOutlinedIcon />} sx={postStyles.tempIcon} />
+          <Button startIcon={<ShareOutlinedIcon />} sx={styles.defaultButton} />
         </Stack>
       </CardActions>
       <Divider light />

--- a/src/components/Posts/PostItem.tsx
+++ b/src/components/Posts/PostItem.tsx
@@ -24,15 +24,6 @@ import { Post, updatePost } from "../../state/slices/postsSlice";
 import { useNavigate } from "react-router-dom";
 import { setExpandedPost } from "../../state/slices/expandedPostSlice";
 
-const styles = {
-  card: {
-    boxShadow: "none",
-  },
-  cardActions: {
-    width: "100%",
-  },
-};
-
 type PostProps = {
   post: Post;
 };
@@ -40,6 +31,20 @@ type PostProps = {
 const PostItem = ({ post }: PostProps) => {
   const dispatch = useAppDispatch();
   const user = useAppSelector((state) => state.user);
+  const styles = {
+    card: {
+      boxShadow: "none",
+    },
+    cardActions: {
+      width: "100%",
+    },
+    likeIcon: {
+      color: post.isLikedByCurrentUser ? "primary.main" : "gray.main",
+      "&:hover": {
+        color: "primary.main",
+      },
+    },
+  };
 
   const likePost = async (postId: number, userId?: number) => {
     await axios.post("http://localhost:3001/api/posts/likePost", {
@@ -123,6 +128,7 @@ const PostItem = ({ post }: PostProps) => {
                 <FavoriteBorderOutlinedIcon />
               )
             }
+            sx={styles.likeIcon}
           >
             {post.numberOfLikes}
           </Button>

--- a/src/components/Posts/PostItem.tsx
+++ b/src/components/Posts/PostItem.tsx
@@ -20,7 +20,7 @@ import RepeatOutlinedIcon from "@mui/icons-material/RepeatOutlined";
 import ShareOutlinedIcon from "@mui/icons-material/ShareOutlined";
 import axios from "axios";
 import { useAppDispatch, useAppSelector } from "../../state/hooks";
-import { Post, updatePost } from "../../state/slices/postsSlice";
+import postsSlice, { Post, updatePost } from "../../state/slices/postsSlice";
 import { useNavigate } from "react-router-dom";
 import { setExpandedPost } from "../../state/slices/expandedPostSlice";
 
@@ -45,6 +45,9 @@ const styles = (post: Post) => ({
     "&:hover": {
       color: "primary.main",
     },
+  },
+  vertIcon: {
+    color: "primary.main",
   },
 });
 
@@ -97,7 +100,7 @@ const PostItem = ({ post }: PostProps) => {
       <CardHeader
         avatar={<Avatar>CK</Avatar>}
         action={
-          <IconButton>
+          <IconButton sx={postStyles.vertIcon}>
             <MoreVertIcon />
           </IconButton>
         }

--- a/src/components/Posts/PostItem.tsx
+++ b/src/components/Posts/PostItem.tsx
@@ -20,7 +20,7 @@ import RepeatOutlinedIcon from "@mui/icons-material/RepeatOutlined";
 import ShareOutlinedIcon from "@mui/icons-material/ShareOutlined";
 import axios from "axios";
 import { useAppDispatch, useAppSelector } from "../../state/hooks";
-import postsSlice, { Post, updatePost } from "../../state/slices/postsSlice";
+import { Post, updatePost } from "../../state/slices/postsSlice";
 import { useNavigate } from "react-router-dom";
 import { setExpandedPost } from "../../state/slices/expandedPostSlice";
 

--- a/src/components/Posts/PostItem.tsx
+++ b/src/components/Posts/PostItem.tsx
@@ -44,6 +44,12 @@ const PostItem = ({ post }: PostProps) => {
         color: "primary.main",
       },
     },
+    tempIcon: {
+      color: "gray.main",
+      "&:hover": {
+        color: "primary.main",
+      },
+    },
   };
 
   const likePost = async (postId: number, userId?: number) => {
@@ -132,9 +138,13 @@ const PostItem = ({ post }: PostProps) => {
           >
             {post.numberOfLikes}
           </Button>
-          <Button startIcon={<AddCommentOutlinedIcon />}>1</Button>
-          <Button startIcon={<RepeatOutlinedIcon />}>1</Button>
-          <Button startIcon={<ShareOutlinedIcon />} />
+          <Button startIcon={<AddCommentOutlinedIcon />} sx={styles.tempIcon}>
+            1
+          </Button>
+          <Button startIcon={<RepeatOutlinedIcon />} sx={styles.tempIcon}>
+            1
+          </Button>
+          <Button startIcon={<ShareOutlinedIcon />} sx={styles.tempIcon} />
         </Stack>
       </CardActions>
       <Divider light />

--- a/src/components/Posts/PostItem.tsx
+++ b/src/components/Posts/PostItem.tsx
@@ -27,30 +27,31 @@ import { setExpandedPost } from "../../state/slices/expandedPostSlice";
 type PostProps = {
   post: Post;
 };
+const styles = (post: Post) => ({
+  card: {
+    boxShadow: "none",
+  },
+  cardActions: {
+    width: "100%",
+  },
+  likeIcon: {
+    color: post.isLikedByCurrentUser ? "primary.main" : "gray.main",
+    "&:hover": {
+      color: "primary.main",
+    },
+  },
+  tempIcon: {
+    color: "gray.main",
+    "&:hover": {
+      color: "primary.main",
+    },
+  },
+});
 
 const PostItem = ({ post }: PostProps) => {
   const dispatch = useAppDispatch();
   const user = useAppSelector((state) => state.user);
-  const styles = {
-    card: {
-      boxShadow: "none",
-    },
-    cardActions: {
-      width: "100%",
-    },
-    likeIcon: {
-      color: post.isLikedByCurrentUser ? "primary.main" : "gray.main",
-      "&:hover": {
-        color: "primary.main",
-      },
-    },
-    tempIcon: {
-      color: "gray.main",
-      "&:hover": {
-        color: "primary.main",
-      },
-    },
-  };
+  const postStyles = styles(post);
 
   const likePost = async (postId: number, userId?: number) => {
     await axios.post("http://localhost:3001/api/posts/likePost", {
@@ -92,7 +93,7 @@ const PostItem = ({ post }: PostProps) => {
   };
 
   return (
-    <Card sx={styles.card}>
+    <Card sx={postStyles.card}>
       <CardHeader
         avatar={<Avatar>CK</Avatar>}
         action={
@@ -119,7 +120,7 @@ const PostItem = ({ post }: PostProps) => {
         <Stack
           direction="row"
           justifyContent="space-between"
-          sx={styles.cardActions}
+          sx={postStyles.cardActions}
         >
           <Button
             onClick={() => {
@@ -134,17 +135,20 @@ const PostItem = ({ post }: PostProps) => {
                 <FavoriteBorderOutlinedIcon />
               )
             }
-            sx={styles.likeIcon}
+            sx={postStyles.likeIcon}
           >
             {post.numberOfLikes}
           </Button>
-          <Button startIcon={<AddCommentOutlinedIcon />} sx={styles.tempIcon}>
+          <Button
+            startIcon={<AddCommentOutlinedIcon />}
+            sx={postStyles.tempIcon}
+          >
             1
           </Button>
-          <Button startIcon={<RepeatOutlinedIcon />} sx={styles.tempIcon}>
+          <Button startIcon={<RepeatOutlinedIcon />} sx={postStyles.tempIcon}>
             1
           </Button>
-          <Button startIcon={<ShareOutlinedIcon />} sx={styles.tempIcon} />
+          <Button startIcon={<ShareOutlinedIcon />} sx={postStyles.tempIcon} />
         </Stack>
       </CardActions>
       <Divider light />

--- a/src/components/Posts/PostItem.tsx
+++ b/src/components/Posts/PostItem.tsx
@@ -46,9 +46,6 @@ const styles = (post: Post) => ({
       color: "primary.main",
     },
   },
-  vertIcon: {
-    color: "primary.main",
-  },
 });
 
 const PostItem = ({ post }: PostProps) => {
@@ -100,7 +97,7 @@ const PostItem = ({ post }: PostProps) => {
       <CardHeader
         avatar={<Avatar>CK</Avatar>}
         action={
-          <IconButton sx={postStyles.vertIcon}>
+          <IconButton sx={postStyles.tempIcon}>
             <MoreVertIcon />
           </IconButton>
         }

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -6,7 +6,6 @@ import MessagesList from "../components/Messages/MessagesList";
 
 const styles = {
   button: {
-    borderRadius: 10,
     marginTop: 1,
   },
   messagesHeader: {

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -30,7 +30,6 @@ const styles = {
   },
   editBtn: {
     backgroundColor: "black",
-    borderRadius: 20,
     textTransform: "none",
     marginLeft: 62,
     marginTop: 2,

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -25,7 +25,6 @@ const styles = {
     fontSize: 32,
   },
   submitButton: {
-    borderRadius: 5,
     width: 253.4,
   },
 };

--- a/src/styles/Theme.tsx
+++ b/src/styles/Theme.tsx
@@ -1,10 +1,17 @@
 import { createTheme } from "@mui/material/styles";
 
+declare module "@mui/material/styles" {
+  interface PaletteOptions {
+    gray: PaletteOptions["primary"];
+  }
+}
+
 const theme = createTheme({
   palette: {
     primary: {
       main: "#22AA6F",
       contrastText: "#FFFFFF",
+      light: "#c6ebd4",
     },
     secondary: {
       main: "#212529",
@@ -17,6 +24,9 @@ const theme = createTheme({
     },
     success: {
       main: "#22AA6F",
+    },
+    gray: {
+      main: "#adb5bd",
     },
   },
 
@@ -31,11 +41,6 @@ const theme = createTheme({
       defaultProps: {
         disableRipple: true,
         disableTouchRipple: true,
-      },
-    },
-    MuiIconButton: {
-      defaultProps: {
-        color: "primary",
       },
     },
   },

--- a/src/styles/Theme.tsx
+++ b/src/styles/Theme.tsx
@@ -1,35 +1,40 @@
 import { createTheme } from "@mui/material/styles";
+import createPalette from "@mui/material/styles/createPalette";
 
-declare module "@mui/material/styles" {
+declare module "@mui/material/styles/createPalette" {
   interface PaletteOptions {
     gray: PaletteOptions["primary"];
   }
+  interface Palette {
+    gray: Palette["primary"];
+  }
 }
 
-const theme = createTheme({
-  palette: {
-    primary: {
-      main: "#22AA6F",
-      contrastText: "#FFFFFF",
-      light: "#c6ebd4",
-    },
-    secondary: {
-      main: "#212529",
-    },
-    error: {
-      main: "#f44336",
-    },
-    warning: {
-      main: "#ffa726",
-    },
-    success: {
-      main: "#22AA6F",
-    },
-    gray: {
-      main: "#adb5bd",
-    },
+const palette = createPalette({
+  primary: {
+    main: "#22AA6F",
+    contrastText: "#FFFFFF",
+    light: "#c6ebd4",
   },
+  secondary: {
+    main: "#212529",
+  },
+  error: {
+    main: "#f44336",
+  },
+  warning: {
+    main: "#ffa726",
+  },
+  success: {
+    main: "#22AA6F",
+  },
+  gray: {
+    main: "#adb5bd",
+  },
+});
 
+const theme = createTheme({
+  palette: palette,
   typography: {
     fontFamily: ["Inter"].join(","), // If we want to add more fonts, we can append to the array.
     button: {
@@ -37,6 +42,17 @@ const theme = createTheme({
     },
   },
   components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: "40px",
+          "&.Mui-disabled": {
+            backgroundColor: palette.primary.light,
+            color: palette.primary.contrastText,
+          },
+        },
+      },
+    },
     MuiButtonBase: {
       defaultProps: {
         disableRipple: true,
@@ -56,8 +72,25 @@ const theme = createTheme({
       },
     },
     MuiIconButton: {
+      styleOverrides: {
+        root: {
+          color: palette.gray.main,
+          "&:hover": {
+            color: palette.primary.main,
+          },
+        },
+      },
+    },
+    MuiTextField: {
       defaultProps: {
-        color: "primary",
+        InputProps: { disableUnderline: true },
+      },
+      styleOverrides: {
+        root: {
+          "&.MuiFormControl-root": {
+            padding: 0,
+          },
+        },
       },
     },
   },


### PR DESCRIPTION
- This issue changes the display for action items within `PostItem` and `ExpandedPostItem` so that the actions are gray when inactive, green on hover, and green when active. 

    - For actions that do not have functionality yet, I have not provided the active/inactive display functionality, but this can either be done within this PR (delay the PR until comment, repost, share functionality is working on main branch) OR we add the display functionality within their respective issues.

    - For example, liking functionality works. We have a boolean that tells the user whether they liked a post or not `isLikedByCurrentUser`. For likes, the display functionality is working.

- I changed the post button disabled color from default gray to a light green on both `ComposeReply` and `ComposePost`.

- I changed the colour of the actions in `ComposePost` and `ComposeReply` to be permanently green.

