### PR TITLE
T58: Page layout template

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,11 +40,7 @@ function App() {
   }, [getAccessTokenSilently, dispatch]);
 
   if (isLoading || (isAuthenticated && user.isLoading)) {
-    return (
-      <div className="App" style={{ display: "flex" }}>
-        <PageLoader />
-      </div>
-    );
+    return <PageLoader />;
   }
 
   if (!isAuthenticated) {
@@ -56,7 +52,7 @@ function App() {
   }
 
   return (
-    <div className="App" style={{ display: "flex" }}>
+    <div className="App">
       <NavBar />
       <Routes>
         <Route path="/" element={<ProtectedRoute component={Timeline} />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
 import Welcome from "./pages/Welcome";
 import Timeline from "./pages/Timeline";
 import { Route, Routes } from "react-router-dom";
-import NavBar from "./components/NavBar/NavBar";
 import { useAuth0 } from "@auth0/auth0-react";
 import axios from "axios";
 import { useEffect } from "react";
@@ -52,28 +51,22 @@ function App() {
   }
 
   return (
-    <div className="App">
-      <NavBar />
-      <Routes>
-        <Route path="/" element={<ProtectedRoute component={Timeline} />} />
-        <Route
-          path="/messages"
-          element={<ProtectedRoute component={Messages} />}
-        />
-        <Route
-          path="/messages/:userId1/:userId2"
-          element={<ProtectedRoute component={DirectMessage} />}
-        />
-        <Route
-          path="/profile"
-          element={<ProtectedRoute component={Profile} />}
-        />
-        <Route
-          path="/post/:postId"
-          element={<ProtectedRoute component={ExpandedPost} />}
-        />
-      </Routes>
-    </div>
+    <Routes>
+      <Route path="/" element={<ProtectedRoute component={Timeline} />} />
+      <Route
+        path="/messages"
+        element={<ProtectedRoute component={Messages} />}
+      />
+      <Route
+        path="/messages/:userId1/:userId2"
+        element={<ProtectedRoute component={DirectMessage} />}
+      />
+      <Route path="/profile" element={<ProtectedRoute component={Profile} />} />
+      <Route
+        path="/post/:postId"
+        element={<ProtectedRoute component={ExpandedPost} />}
+      />
+    </Routes>
   );
 }
 

--- a/src/components/Messages/ConversationList.tsx
+++ b/src/components/Messages/ConversationList.tsx
@@ -12,16 +12,11 @@ import ChatOutlinedIcon from "@mui/icons-material/ChatOutlined";
 import SearchBar from "../Common/SearchBar";
 
 const styles = {
-  container: {
-    maxWidth: "30%",
-  },
   header: {
     display: "flex",
     justifyContent: "space-between",
     paddingTop: 2,
-    paddingRight: 2,
-    paddingLeft: 2,
-    paddingBottom: 0,
+    paddingX: 2,
   },
 };
 
@@ -47,7 +42,7 @@ const ConversationList = () => {
   }, [dispatch, user]);
 
   return (
-    <Box sx={styles.container}>
+    <Box>
       <Box sx={styles.header}>
         <Typography variant="h6">Messages</Typography>
         <IconButton>

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -79,7 +79,6 @@ const NavBar = () => {
                 />
               ))}
             </List>
-            {/*/ Update the button to post action*/}
             <Button
               sx={styles.postButton}
               variant="contained"

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -1,8 +1,7 @@
 import HomeIcon from "@mui/icons-material/Home";
 import MailIcon from "@mui/icons-material/Mail";
 import AccountCircleIcon from "@mui/icons-material/AccountCircle";
-import { Avatar, Button, List, Stack, Toolbar } from "@mui/material";
-import { Drawer } from "@mui/material";
+import { Avatar, Box, Button, List, Toolbar } from "@mui/material";
 import AccountMenu from "./AccountMenu";
 import NavItem from "./NavItem";
 import PostButtonModal from "./PostButtonModal";
@@ -10,26 +9,18 @@ import { useState } from "react";
 import ComposePost from "../Posts/ComposePost";
 import { useAppSelector } from "../../state/hooks";
 
-const drawerWidth = "30%";
 const styles = {
   logo: { alignSelf: "left", paddingTop: 2, paddingLeft: 2 },
-  navDrawer: {
+  navList: {
+    display: "flex",
+    flexDirection: "column",
     height: "100%",
-    width: drawerWidth,
-    "& .MuiDrawer-paper": {
-      boxSizing: "border-box",
-      width: drawerWidth,
-    },
-  },
-  postButton: { margin: 2 },
-  stack: {
     marginBottom: "auto",
     width: "100%",
-    height: "100%",
   },
+  postButton: { margin: 2 },
   toolbar: {
     height: "100%",
-    width: "40%",
     marginLeft: "auto",
   },
 };
@@ -61,35 +52,33 @@ const NavBar = () => {
 
   return (
     <>
-      <Drawer variant="permanent" anchor="left" sx={styles.navDrawer}>
-        <Toolbar sx={styles.toolbar}>
-          <Stack sx={styles.stack}>
-            <Avatar
-              alt="logo"
-              src="https://www.iconpacks.net/icons/2/free-twitter-logo-icon-2429-thumb.png"
-              sx={styles.logo}
-            />
-            <List component="nav">
-              {navItems.map((navItem, index) => (
-                <NavItem
-                  key={index}
-                  icon={navItem.icon}
-                  label={navItem.label}
-                  route={navItem.route}
-                />
-              ))}
-            </List>
-            <Button
-              sx={styles.postButton}
-              variant="contained"
-              onClick={() => setOpenModal(true)}
-            >
-              Post
-            </Button>
-            <AccountMenu />
-          </Stack>
-        </Toolbar>
-      </Drawer>
+      <Toolbar sx={styles.toolbar}>
+        <Box sx={styles.navList}>
+          <Avatar
+            alt="logo"
+            src="https://www.iconpacks.net/icons/2/free-twitter-logo-icon-2429-thumb.png"
+            sx={styles.logo}
+          />
+          <List component="nav">
+            {navItems.map((navItem, index) => (
+              <NavItem
+                key={index}
+                icon={navItem.icon}
+                label={navItem.label}
+                route={navItem.route}
+              />
+            ))}
+          </List>
+          <Button
+            sx={styles.postButton}
+            variant="contained"
+            onClick={() => setOpenModal(true)}
+          >
+            Post
+          </Button>
+          <AccountMenu />
+        </Box>
+      </Toolbar>
       <PostButtonModal
         onClose={() => setOpenModal(false)}
         openModal={openModal}

--- a/src/components/Posts/ExpandedPostItem.tsx
+++ b/src/components/Posts/ExpandedPostItem.tsx
@@ -50,6 +50,7 @@ const styles = {
     paddingLeft: 0.5,
     fontSize: 14.5,
   },
+  backButton: { "&:hover": { backgroundColor: "transparent" } },
   card: {
     padding: 0,
     boxShadow: "none",
@@ -143,7 +144,7 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
   return (
     <Card sx={styles.card}>
       <Box style={styles.topHeader}>
-        <IconButton onClick={() => navigate(-1)}>
+        <IconButton onClick={() => navigate(-1)} sx={styles.backButton}>
           <KeyboardBackspaceIcon color="secondary" />
         </IconButton>
         <Typography style={styles.headerTitle}>Post</Typography>

--- a/src/components/Posts/ExpandedPostItem.tsx
+++ b/src/components/Posts/ExpandedPostItem.tsx
@@ -48,10 +48,6 @@ const styles = {
     paddingLeft: 0.5,
     fontSize: 14.5,
   },
-  backButton: {
-    backgroundColor: "transparent",
-    paddingRight: 10,
-  },
   card: {
     padding: 0,
     boxShadow: "none",
@@ -141,7 +137,7 @@ const ExpandedPostItem = () => {
   return (
     <Card sx={styles.card}>
       <Box style={styles.topHeader}>
-        <IconButton style={styles.backButton} onClick={() => navigate(-1)}>
+        <IconButton onClick={() => navigate(-1)}>
           <KeyboardBackspaceIcon color="secondary" />
         </IconButton>
         <Typography style={styles.headerTitle}>Post</Typography>

--- a/src/pages/DirectMessage.tsx
+++ b/src/pages/DirectMessage.tsx
@@ -251,7 +251,6 @@ const DirectMessage = () => {
           </Box>
         </Box>
       </Box>
-      <Divider orientation="vertical" />
     </Stack>
   );
 };

--- a/src/pages/DirectMessage.tsx
+++ b/src/pages/DirectMessage.tsx
@@ -32,6 +32,7 @@ const styles = {
   container: { height: "auto", justifyContent: "center" },
   chatContainer: {
     display: "flex",
+    flex: 1,
     flexDirection: "column",
     overflowY: "hidden",
   },
@@ -58,7 +59,7 @@ const styles = {
     flexDirection: "column",
     alignItems: "flex-start",
   },
-  messageList: { overflowY: "scroll" },
+  messageList: { flex: 1, overflowY: "scroll" },
   messageText: {
     padding: 1,
     borderRadius: 10,

--- a/src/pages/DirectMessage.tsx
+++ b/src/pages/DirectMessage.tsx
@@ -26,11 +26,12 @@ import {
   updateConversation,
 } from "../state/slices/messagesSlice";
 import theme from "../styles/Theme";
+import NavBar from "../components/NavBar/NavBar";
 
 const styles = {
+  container: { height: "auto", justifyContent: "center" },
   chatContainer: {
     display: "flex",
-    flex: 1,
     flexDirection: "column",
     overflowY: "hidden",
   },
@@ -40,11 +41,11 @@ const styles = {
     width: "100%",
   },
   directMessageContainer: {
-    width: "50%",
     display: "flex",
     flexDirection: "column",
     height: "100%",
   },
+  divider: { height: "auto" },
   headerContainer: {
     display: "flex",
     justifyContent: "space-between",
@@ -57,14 +58,17 @@ const styles = {
     flexDirection: "column",
     alignItems: "flex-start",
   },
-  messageList: { flex: 1, overflowY: "scroll" },
+  messageList: { overflowY: "scroll" },
   messageText: {
     padding: 1,
     borderRadius: 10,
     backgroundColor: "#cce3d9",
   },
-  root: {
-    width: "100%",
+  middleContent: { flex: "0 0 350px", height: "100vh", minWidth: 0 },
+  nav: { flex: "0 0 275px", height: "100vh", position: "sticky", top: 0 },
+  rightContent: {
+    height: "100vh",
+    flex: "0 0 600px",
   },
   sentMessage: {
     display: "flex",
@@ -148,97 +152,106 @@ const DirectMessage = () => {
   return (
     <Stack
       direction="row"
-      sx={styles.root}
-      divider={<Divider flexItem orientation="vertical" />}
+      divider={<Divider orientation="vertical" sx={styles.divider} />}
+      sx={styles.container}
     >
-      <ConversationList />
-      <Box sx={styles.directMessageContainer}>
-        <Box sx={styles.headerContainer}>
-          <Box sx={styles.headerContent}>
-            <Box>
+      <Box component="header" sx={styles.nav}>
+        <NavBar />
+      </Box>
+      <Box sx={styles.middleContent}>
+        <ConversationList />
+      </Box>
+      <Box sx={styles.rightContent}>
+        <Box sx={styles.directMessageContainer}>
+          <Box sx={styles.headerContainer}>
+            <Box sx={styles.headerContent}>
               <Avatar />
+              <Box>
+                <Typography variant="subtitle1">
+                  {selectedConversation.displayName}
+                </Typography>
+                <Typography variant="subtitle2">{`@${selectedConversation.username}`}</Typography>
+              </Box>
             </Box>
-            <Box>
-              <Typography variant="subtitle1">
-                {selectedConversation.displayName}
-              </Typography>
-              <Typography variant="subtitle2">{`@${selectedConversation.username}`}</Typography>
-            </Box>
+            <IconButton>
+              <InfoOutlinedIcon />
+            </IconButton>
           </Box>
-          <IconButton>
-            <InfoOutlinedIcon />
-          </IconButton>
-        </Box>
-        <Divider flexItem />
-        <Box sx={styles.chatContainer}>
-          <List component="div" ref={messageRef} sx={styles.messageList}>
-            {messages.map((o) => (
-              <ListItem component="div" key={o.messageId}>
-                <ListItemText
-                  sx={
-                    o.sentUserId === user.userId
-                      ? styles.sentMessage
-                      : styles.message
-                  }
-                  disableTypography
-                  primary={
-                    <Box
-                      sx={
-                        o.sentUserId === user.userId
-                          ? styles.sentMessageText
-                          : styles.messageText
-                      }
-                    >
-                      <Typography variant="body2">{o.textContent}</Typography>
-                    </Box>
-                  }
-                  secondary={
-                    <Typography sx={styles.timestamp} variant="caption">
-                      {o.timestamp}
-                    </Typography>
-                  }
-                />
-              </ListItem>
-            ))}
-          </List>
           <Divider />
-          <form onSubmit={onSubmit}>
-            <Box sx={styles.chatInputContainer}>
-              <TextField
-                autoComplete="off"
-                fullWidth
-                hiddenLabel
-                InputProps={{
-                  startAdornment: (
-                    <InputAdornment position="start">
-                      <IconButton>
-                        <AddPhotoAlternateOutlinedIcon />
-                      </IconButton>
-                      <IconButton>
-                        <EmojiEmotionsOutlinedIcon />
-                      </IconButton>
-                      <IconButton>
-                        <GifBoxOutlinedIcon />
-                      </IconButton>
-                    </InputAdornment>
-                  ),
-                  endAdornment: (
-                    <InputAdornment position="end">
-                      <IconButton type="submit" disabled={!textContent.trim()}>
-                        <SendIcon />
-                      </IconButton>
-                    </InputAdornment>
-                  ),
-                }}
-                onChange={(e) => setTextContent(e.target.value)}
-                placeholder="Send a message"
-                size="small"
-                value={textContent}
-              />
-            </Box>
-          </form>
+          <Box sx={styles.chatContainer}>
+            <List component="div" ref={messageRef} sx={styles.messageList}>
+              {messages.map((o) => (
+                <ListItem component="div" key={o.messageId}>
+                  <ListItemText
+                    sx={
+                      o.sentUserId === user.userId
+                        ? styles.sentMessage
+                        : styles.message
+                    }
+                    disableTypography
+                    primary={
+                      <Box
+                        sx={
+                          o.sentUserId === user.userId
+                            ? styles.sentMessageText
+                            : styles.messageText
+                        }
+                      >
+                        <Typography variant="body2">{o.textContent}</Typography>
+                      </Box>
+                    }
+                    secondary={
+                      <Typography sx={styles.timestamp} variant="caption">
+                        {o.timestamp}
+                      </Typography>
+                    }
+                  />
+                </ListItem>
+              ))}
+            </List>
+            <Divider />
+            <form onSubmit={onSubmit}>
+              <Box sx={styles.chatInputContainer}>
+                <TextField
+                  autoComplete="off"
+                  fullWidth
+                  hiddenLabel
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <IconButton>
+                          <AddPhotoAlternateOutlinedIcon />
+                        </IconButton>
+                        <IconButton>
+                          <EmojiEmotionsOutlinedIcon />
+                        </IconButton>
+                        <IconButton>
+                          <GifBoxOutlinedIcon />
+                        </IconButton>
+                      </InputAdornment>
+                    ),
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <IconButton
+                          type="submit"
+                          disabled={!textContent.trim()}
+                        >
+                          <SendIcon />
+                        </IconButton>
+                      </InputAdornment>
+                    ),
+                  }}
+                  onChange={(e) => setTextContent(e.target.value)}
+                  placeholder="Send a message"
+                  size="small"
+                  value={textContent}
+                />
+              </Box>
+            </form>
+          </Box>
         </Box>
       </Box>
+      <Divider orientation="vertical" />
     </Stack>
   );
 };

--- a/src/pages/ExpandedPost.tsx
+++ b/src/pages/ExpandedPost.tsx
@@ -1,27 +1,27 @@
 import { Box, Divider } from "@mui/material";
-import { Stack } from "@mui/system";
 import ExpandedPostItem from "../components/Posts/ExpandedPostItem";
 import ComposeReply from "../components/Posts/ComposeReply";
 import ExpandedPostList from "../components/Posts/ExpandedPostReplies";
+import Layout from "./Layout";
 
 const styles = {
   root: {
     width: "100%",
   },
-  postListContainer: { padding: 0, width: "50%" },
 };
 
 const ExpandedPost = () => {
   return (
-    <Stack direction="row" sx={styles.root}>
-      <Box sx={styles.postListContainer}>
-        <ExpandedPostItem />
-        <ComposeReply placeholder="Post your reply" />
-        <Divider />
-        <ExpandedPostList />
-      </Box>
-      <Divider orientation="vertical" />
-    </Stack>
+    <Layout
+      mainContent={
+        <Box sx={styles.root}>
+          <ExpandedPostItem />
+          <ComposeReply placeholder="Post your reply" />
+          <Divider />
+          <ExpandedPostList />
+        </Box>
+      }
+    />
   );
 };
 

--- a/src/pages/ExpandedPost.tsx
+++ b/src/pages/ExpandedPost.tsx
@@ -26,18 +26,6 @@ const ExpandedPost = () => {
           <ExpandedPostReplies post={expandedPost} />
         </Box>
       }
-      rightContent={
-        <Box>
-          <ExpandedPostItem post={expandedPost} />
-          <Divider sx={styles.divider} variant="middle" />
-          <ComposeReply
-            placeholder="Post your reply"
-            parentPostId={expandedPost.postId}
-          />
-          <Divider />
-          <ExpandedPostReplies post={expandedPost} />
-        </Box>
-      }
     />
   );
 };

--- a/src/pages/ExpandedPost.tsx
+++ b/src/pages/ExpandedPost.tsx
@@ -6,9 +6,6 @@ import { useAppSelector } from "../state/hooks";
 import Layout from "./Layout";
 
 const styles = {
-  root: {
-    width: "100%",
-  },
   divider: { marginBottom: 3 },
 };
 
@@ -17,8 +14,20 @@ const ExpandedPost = () => {
 
   return (
     <Layout
-      mainContent={
-        <Box sx={styles.root}>
+      middleContent={
+        <Box>
+          <ExpandedPostItem post={expandedPost} />
+          <Divider sx={styles.divider} variant="middle" />
+          <ComposeReply
+            placeholder="Post your reply"
+            parentPostId={expandedPost.postId}
+          />
+          <Divider />
+          <ExpandedPostReplies post={expandedPost} />
+        </Box>
+      }
+      rightContent={
+        <Box>
           <ExpandedPostItem post={expandedPost} />
           <Divider sx={styles.divider} variant="middle" />
           <ComposeReply

--- a/src/pages/Layout.tsx
+++ b/src/pages/Layout.tsx
@@ -1,0 +1,36 @@
+import { ReactElement } from "react";
+import NavBar from "../components/NavBar/NavBar";
+import { Box, Divider, Stack } from "@mui/material";
+
+const styles = {
+  container: { height: "100%", justifyContent: "center" },
+  mainContent: { flex: "0 1 600px" },
+  nav: { flex: "0 0 275px" },
+  secondaryContent: {
+    flex: "0 0 350px",
+    paddingLeft: "40px",
+  },
+};
+
+type LayoutProps = {
+  mainContent: ReactElement;
+  secondaryContent?: ReactElement;
+};
+
+const Layout = ({ mainContent, secondaryContent }: LayoutProps) => {
+  return (
+    <Stack
+      direction="row"
+      sx={styles.container}
+      divider={<Divider orientation="vertical" />}
+    >
+      <Box component="header" sx={styles.nav}>
+        <NavBar />
+      </Box>
+      <Box sx={styles.mainContent}>{mainContent}</Box>
+      <Box sx={styles.secondaryContent}>{secondaryContent}</Box>
+    </Stack>
+  );
+};
+
+export default Layout;

--- a/src/pages/Layout.tsx
+++ b/src/pages/Layout.tsx
@@ -5,31 +5,33 @@ import { Box, Divider, Stack } from "@mui/material";
 const styles = {
   container: { height: "auto", justifyContent: "center" },
   divider: { height: "auto" },
-  mainContent: { flex: "0 1 600px" },
+  middleContent: { flex: "0 1 600px", minWidth: 0 },
   nav: { flex: "0 0 275px", height: "100vh", position: "sticky", top: 0 },
-  secondaryContent: {
+  rightContent: {
+    boxSizing: "border-box",
     flex: "0 0 350px",
+    minWidth: 0,
     paddingLeft: "40px",
   },
 };
 
 type LayoutProps = {
-  mainContent: ReactElement;
-  secondaryContent?: ReactElement;
+  middleContent: ReactElement;
+  rightContent?: ReactElement;
 };
 
-const Layout = ({ mainContent, secondaryContent }: LayoutProps) => {
+const Layout = ({ middleContent, rightContent }: LayoutProps) => {
   return (
     <Stack
       direction="row"
-      sx={styles.container}
       divider={<Divider orientation="vertical" sx={styles.divider} />}
+      sx={styles.container}
     >
       <Box component="header" sx={styles.nav}>
         <NavBar />
       </Box>
-      <Box sx={styles.mainContent}>{mainContent}</Box>
-      <Box sx={styles.secondaryContent}>{secondaryContent}</Box>
+      <Box sx={styles.middleContent}>{middleContent}</Box>
+      <Box sx={styles.rightContent}>{rightContent}</Box>
     </Stack>
   );
 };

--- a/src/pages/Layout.tsx
+++ b/src/pages/Layout.tsx
@@ -3,9 +3,10 @@ import NavBar from "../components/NavBar/NavBar";
 import { Box, Divider, Stack } from "@mui/material";
 
 const styles = {
-  container: { height: "100%", justifyContent: "center" },
+  container: { height: "auto", justifyContent: "center" },
+  divider: { height: "auto" },
   mainContent: { flex: "0 1 600px" },
-  nav: { flex: "0 0 275px" },
+  nav: { flex: "0 0 275px", height: "100vh", position: "sticky", top: 0 },
   secondaryContent: {
     flex: "0 0 350px",
     paddingLeft: "40px",
@@ -22,7 +23,7 @@ const Layout = ({ mainContent, secondaryContent }: LayoutProps) => {
     <Stack
       direction="row"
       sx={styles.container}
-      divider={<Divider orientation="vertical" />}
+      divider={<Divider orientation="vertical" sx={styles.divider} />}
     >
       <Box component="header" sx={styles.nav}>
         <NavBar />

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -28,39 +28,41 @@ const Messages = () => {
   const [messageModal, showMessageModal] = useState(false);
 
   return (
-    <Stack
-      direction="row"
-      divider={<Divider orientation="vertical" sx={styles.divider} />}
-      sx={styles.container}
-    >
-      <Box component="header" sx={styles.nav}>
-        <NavBar />
-      </Box>
-      <Box sx={styles.middleContent}>
-        <ConversationList />
-      </Box>
-      <Box sx={styles.rightContent}>
-        <Box sx={styles.selectMessageContainer}>
-          <Box>
-            <Typography variant="h6">Select a Message</Typography>
-            <Typography>
-              Choose one of your existing conversations or start a new one!
-            </Typography>
-            <Button
-              onClick={() => showMessageModal(true)}
-              sx={styles.button}
-              variant="contained"
-            >
-              New Message
-            </Button>
+    <>
+      <Stack
+        direction="row"
+        divider={<Divider orientation="vertical" sx={styles.divider} />}
+        sx={styles.container}
+      >
+        <Box component="header" sx={styles.nav}>
+          <NavBar />
+        </Box>
+        <Box sx={styles.middleContent}>
+          <ConversationList />
+        </Box>
+        <Box sx={styles.rightContent}>
+          <Box sx={styles.selectMessageContainer}>
+            <Box>
+              <Typography variant="h6">Select a Message</Typography>
+              <Typography>
+                Choose one of your existing conversations or start a new one!
+              </Typography>
+              <Button
+                onClick={() => showMessageModal(true)}
+                sx={styles.button}
+                variant="contained"
+              >
+                New Message
+              </Button>
+            </Box>
           </Box>
         </Box>
-      </Box>
+      </Stack>
       <CreateMessageModal
         onClose={() => showMessageModal(false)}
         open={messageModal}
       />
-    </Stack>
+    </>
   );
 };
 

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -1,39 +1,54 @@
 import { Box, Button, Divider, Stack, Typography } from "@mui/material";
 import ConversationList from "../components/Messages/ConversationList";
+import NavBar from "../components/NavBar/NavBar";
 
 const styles = {
   button: {
     marginTop: 1,
   },
-  root: {
-    width: "100%",
+  container: { height: "auto", justifyContent: "center" },
+  divider: { height: "auto" },
+  middleContent: { flex: "0 0 350px", height: "100vh", minWidth: 0 },
+  nav: { flex: "0 0 275px", height: "100vh", position: "sticky", top: 0 },
+  rightContent: {
+    height: "100vh",
+    flex: "0 0 600px",
   },
   selectMessageContainer: {
     display: "flex",
-    flexDirection: "column",
+    height: "100%",
     justifyContent: "center",
     alignItems: "center",
-    width: "50%",
   },
 };
 
 const Messages = () => {
   return (
-    <Stack direction="row" sx={styles.root}>
-      <ConversationList />
-      <Divider flexItem orientation="vertical" />
-      <Box sx={styles.selectMessageContainer}>
-        <Box>
-          <Typography variant="h6">Select a Message</Typography>
-          <Typography>
-            Choose one of your existing conversations or start a new one!
-          </Typography>
-          <Button variant="contained" sx={styles.button}>
-            New Message
-          </Button>
+    <Stack
+      direction="row"
+      divider={<Divider orientation="vertical" sx={styles.divider} />}
+      sx={styles.container}
+    >
+      <Box component="header" sx={styles.nav}>
+        <NavBar />
+      </Box>
+      <Box sx={styles.middleContent}>
+        <ConversationList />
+      </Box>
+      <Box sx={styles.rightContent}>
+        <Box sx={styles.selectMessageContainer}>
+          <Box>
+            <Typography variant="h6">Select a Message</Typography>
+            <Typography>
+              Choose one of your existing conversations or start a new one!
+            </Typography>
+            <Button variant="contained" sx={styles.button}>
+              New Message
+            </Button>
+          </Box>
         </Box>
       </Box>
-      <Divider orientation="vertical" flexItem />
+      <Divider orientation="vertical" />
     </Stack>
   );
 };

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -48,7 +48,6 @@ const Messages = () => {
           </Box>
         </Box>
       </Box>
-      <Divider orientation="vertical" />
     </Stack>
   );
 };

--- a/src/pages/PageLoader.tsx
+++ b/src/pages/PageLoader.tsx
@@ -1,9 +1,18 @@
 import CircularProgress from "@mui/material/CircularProgress";
 import Box from "@mui/system/Box";
 
+const styles = {
+  container: {
+    alignItems: "center",
+    display: "flex",
+    height: "100%",
+    justifyContent: "center",
+  },
+};
+
 const PageLoader = () => {
   return (
-    <Box sx={{ margin: "auto" }}>
+    <Box sx={styles.container}>
       <CircularProgress />
     </Box>
   );

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -97,7 +97,7 @@ const Profile = () => {
 
   return (
     <Layout
-      mainContent={
+      middleContent={
         <Box>
           <Box style={styles.header}>
             <IconButton onClick={() => navigate(-1)}>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -14,85 +14,46 @@ import IconButton from "@mui/material/IconButton/IconButton";
 import Layout from "./Layout";
 
 const styles = {
-  arrowBtn: {
-    border: "none",
-    backgroundColor: "white",
-  },
-  arrowText: {
-    fontSize: 20,
-    fontWeight: "bold",
-  },
   avatar: {
-    width: 140,
     height: 140,
-    left: 25,
-    zIndex: 2,
-    top: -80,
+    marginTop: "-15%",
+    width: 140,
   },
-  editBtn: {
-    backgroundColor: "black",
-    textTransform: "none",
-    marginLeft: 62,
-    marginTop: 2,
+  avatarContainer: {
+    alignItems: "flex-start",
+    display: "flex",
+    justifyContent: "space-between",
   },
+  banner: { width: "100%", height: "200px" },
+  bio: { paddingTop: 1 },
   displayName: {
-    fontSize: 25,
-    marginTop: 10,
-    marginBottom: 5,
+    fontSize: 20,
     fontWeight: "bold",
   },
-  usernameDisplay: {
-    fontWeight: "normal",
-    fontSize: 20,
-    color: "#71797E",
-    marginBottom: 15,
+  editProfileButton: {
+    backgroundColor: "black",
   },
-  menu: { marginTop: 60, marginRight: 83 },
-  tabSelection: {
-    marginLeft: 85,
+  followerButtons: {
+    color: "black",
+    padding: 0,
+    textTransform: "none",
   },
+  followerContainer: { paddingTop: 1, display: "flex", gap: 3 },
   header: {
-    height: "60px",
-    paddingTop: 10,
-    display: "flex",
-    alignItems: "center",
-  },
-  tweetCountStyle: { fontWeight: "normal", fontSize: 15 },
-  followercountbtn: {
-    border: "none",
-    fontSize: 15,
-    padding: 0,
-    backgroundColor: "white",
-    color: "black",
-    textTransform: "none",
-    marginTop: 2,
-  },
-  followingcountbtn: {
-    border: "none",
-    fontSize: 15,
-    padding: 0,
-    marginLeft: 5,
-    color: "black",
-    backgroundColor: "white",
-    textTransform: "none",
-    marginTop: 2,
-  },
-  bioDisplay: {
-    marginBottom: 20,
-  },
-  parentBox: {
-    width: "100%",
-  },
-  avatarBannerBox: {
-    height: 200,
-  },
-  profileInfoBox: {
-    paddingLeft: 15,
-    paddingTop: 20,
-  },
-  calendarBox: {
     alignItems: "center",
     display: "flex",
+  },
+  joinedDate: {
+    display: "flex",
+    gap: 0.5,
+    paddingTop: 1,
+  },
+  nameContainer: { paddingTop: 1 },
+  profileContent: { padding: 2 },
+  tweetCount: { fontSize: 13 },
+  username: {
+    color: "#71797E",
+    fontSize: 16,
   },
 };
 
@@ -131,81 +92,90 @@ const Profile = () => {
         joinedDate: formattedDate,
       });
     };
-
     fetchProfileContents();
   }, [value, user]);
+
   return (
     <Layout
       mainContent={
         <Box>
           <Box style={styles.header}>
-            <IconButton style={styles.arrowBtn} onClick={() => navigate(-1)}>
+            <IconButton onClick={() => navigate(-1)}>
               <KeyboardBackspaceIcon color="secondary" />
             </IconButton>
             <Box>
-              <Typography sx={styles.arrowText}>{user.username}</Typography>
-              <Typography sx={styles.tweetCountStyle}>
+              <Typography sx={styles.displayName}>
+                {user.displayName}
+              </Typography>
+              <Typography sx={styles.tweetCount}>
                 {profileContents.postCount} Tweets
               </Typography>
             </Box>
           </Box>
-          <Box sx={styles.avatarBannerBox}>
+          <Box>
             <Box
               component="img"
-              sx={{ position: "relative", width: "100%", height: "200px" }}
+              sx={styles.banner}
               src={process.env.PUBLIC_URL + "/blue.jpg"}
-              alt="temp"
+              alt="Temp"
             />
-            <Avatar
-              alt="profile picture"
-              src={process.env.PUBLIC_URL + "/rock.jpg"}
-              sx={styles.avatar}
-            />
-          </Box>
-          <Button
-            variant="contained"
-            startIcon={<EditIcon />}
-            sx={styles.editBtn}
-          >
-            Edit Profile
-          </Button>
-
-          <Box style={styles.profileInfoBox}>
-            <Typography variant={"h2"} style={styles.displayName}>
-              {user.displayName}
-            </Typography>
-            <Typography variant={"h3"} style={styles.usernameDisplay}>
-              @{user.username}
-            </Typography>
-            <Typography style={styles.bioDisplay}>
-              {profileContents.bio}
-            </Typography>
-            <Box style={styles.calendarBox}>
-              <CalendarMonthIcon />
-              <Typography>Joined {profileContents.joinedDate}</Typography>
+            <Box sx={styles.profileContent}>
+              <Box sx={styles.avatarContainer}>
+                <Avatar
+                  alt="Profile Picture"
+                  src={process.env.PUBLIC_URL + "/rock.jpg"}
+                  sx={styles.avatar}
+                />
+                <Button
+                  variant="contained"
+                  startIcon={<EditIcon />}
+                  sx={styles.editProfileButton}
+                >
+                  Edit Profile
+                </Button>
+              </Box>
+              <Box sx={styles.nameContainer}>
+                <Typography variant="h2" sx={styles.displayName}>
+                  {user.displayName}
+                </Typography>
+                <Typography variant="h3" sx={styles.username}>
+                  @{user.username}
+                </Typography>
+              </Box>
+              <Typography sx={styles.bio}>{profileContents.bio}</Typography>
+              <Box sx={styles.joinedDate}>
+                <CalendarMonthIcon />
+                <Typography>Joined {profileContents.joinedDate}</Typography>
+              </Box>
+              <Box sx={styles.followerContainer}>
+                <Button sx={styles.followerButtons}>
+                  <Typography component="span" sx={{ fontWeight: "bold" }}>
+                    500M
+                  </Typography>
+                  <Typography component="span">Followers</Typography>
+                </Button>
+                <Button sx={styles.followerButtons}>
+                  <Typography component="span" sx={{ fontWeight: "bold" }}>
+                    0
+                  </Typography>
+                  <Typography component="span">Following</Typography>
+                </Button>
+              </Box>
             </Box>
-            <Button sx={styles.followercountbtn}>
-              <Box>
-                <b>500M</b> Followers
-              </Box>
-            </Button>
-            <Button sx={styles.followingcountbtn}>
-              <Box>
-                <b>0</b> Following
-              </Box>
-            </Button>
           </Box>
           <Tabs
-            value={value}
+            centered
+            component="nav"
             onChange={(_: React.SyntheticEvent, newValue: string) =>
               setValue(newValue)
             }
+            value={value}
+            variant="fullWidth"
           >
-            <Tab value="one" style={styles.tabSelection} label="Tweets" />
-            <Tab value="two" style={styles.tabSelection} label="Replies" />
-            <Tab value="three" style={styles.tabSelection} label="Likes" />
+            <Tab value="one" label="Tweets" />
+            <Tab value="two" label="Replies" />
+            <Tab value="three" label="Likes" />
           </Tabs>
-
           {value === "one" && (
             <Box>
               <ProfileTweets />
@@ -216,7 +186,6 @@ const Profile = () => {
               <ProfileReplies />
             </Box>
           )}
-
           {value === "three" && (
             <Box>
               <ProfileLikes />

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -11,6 +11,7 @@ import ProfileLikes from "../components/Profile/ProfileLikes";
 import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
 import { useNavigate } from "react-router-dom";
 import IconButton from "@mui/material/IconButton/IconButton";
+import Layout from "./Layout";
 
 const styles = {
   arrowBtn: {
@@ -80,7 +81,7 @@ const styles = {
     marginBottom: 20,
   },
   parentBox: {
-    width: 650,
+    width: "100%",
   },
   avatarBannerBox: {
     height: 200,
@@ -134,8 +135,8 @@ const Profile = () => {
     fetchProfileContents();
   }, [value, user]);
   return (
-    <>
-      <Box style={styles.parentBox}>
+    <Layout
+      mainContent={
         <Box>
           <Box style={styles.header}>
             <IconButton style={styles.arrowBtn} onClick={() => navigate(-1)}>
@@ -151,7 +152,7 @@ const Profile = () => {
           <Box sx={styles.avatarBannerBox}>
             <Box
               component="img"
-              sx={{ position: "relative", width: "650px", height: "200px" }}
+              sx={{ position: "relative", width: "100%", height: "200px" }}
               src={process.env.PUBLIC_URL + "/blue.jpg"}
               alt="temp"
             />
@@ -222,8 +223,8 @@ const Profile = () => {
             </Box>
           )}
         </Box>
-      </Box>
-    </>
+      }
+    />
   );
 };
 

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -8,24 +8,19 @@ import { useAppDispatch, useAppSelector } from "./../state/hooks";
 import { setUser } from "../state/slices/userSlice";
 
 const styles = {
-  container: {
-    alignItems: "center",
-    display: "flex",
-    flexDirection: "column",
-    gap: 2,
-    height: "100%",
-    paddingTop: 5,
-  },
-  datePicker: {
-    width: 253.4,
-  },
+  container: { height: "100%" },
   title: {
-    textAlign: "center",
     fontWeight: 700,
     fontSize: 32,
+    padding: 3,
+    textAlign: "center",
   },
-  submitButton: {
-    width: 253.4,
+  inputs: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 3,
+    margin: "auto",
+    width: "15%",
   },
 };
 
@@ -63,60 +58,53 @@ const Register = () => {
   };
 
   return (
-    <form onSubmit={submitUserInfo}>
-      <Box sx={styles.container}>
-        <Typography variant="h1" sx={styles.title}>
-          Let's get to know a little more about you
-        </Typography>
+    <form onSubmit={submitUserInfo} style={styles.container}>
+      <Typography variant="h1" sx={styles.title}>
+        Let's get to know a little more about you
+      </Typography>
+      <Box sx={styles.inputs}>
         <TextField
+          id="displayname"
           label="Username"
-          required
-          value={username}
           onChange={(e) => {
             setUsername(e.target.value);
           }}
-          type="text"
-          variant="outlined"
           placeholder="Username"
-          id="displayname"
+          required
+          type="text"
+          value={username}
+          variant="outlined"
         />
         <TextField
+          id="displayname"
           label="Display Name"
-          value={displayName}
           onChange={(e) => {
             setDisplayName(e.target.value);
           }}
-          type="text"
-          variant="outlined"
           placeholder="Display Name"
-          id="displayname"
+          type="text"
+          value={displayName}
+          variant="outlined"
         />
         <LocalizationProvider dateAdapter={AdapterDayjs}>
           <DatePicker
             renderInput={(props) => (
               <TextField
-                sx={styles.datePicker}
-                variant="outlined"
                 id="date"
                 placeholder="Date of Birth"
+                variant="outlined"
                 {...props}
               />
             )}
             label="Date of Birth"
-            value={birthDate}
+            maxDate={new Date()}
             onChange={(e) => {
               e && setBirthDate(e);
             }}
-            maxDate={new Date()}
+            value={birthDate}
           />
         </LocalizationProvider>
-        <Button
-          size="large"
-          sx={styles.submitButton}
-          color="primary"
-          variant="contained"
-          type="submit"
-        >
+        <Button size="large" type="submit" variant="contained">
           Submit
         </Button>
       </Box>

--- a/src/pages/Timeline.tsx
+++ b/src/pages/Timeline.tsx
@@ -4,11 +4,6 @@ import PostList from "../components/Posts/PostList";
 import Layout from "./Layout";
 
 const styles = {
-  root: {
-    display: "flex",
-    flexDirection: "column",
-    width: "100%",
-  },
   headerTitle: {
     fontWeight: "bold",
     paddingX: 2,
@@ -19,8 +14,8 @@ const styles = {
 const Timeline = () => {
   return (
     <Layout
-      mainContent={
-        <Box sx={styles.root}>
+      middleContent={
+        <Box>
           <Typography sx={styles.headerTitle}>Timeline</Typography>
           <ComposePost placeholder="What's happening?" />
           <Divider />

--- a/src/pages/Timeline.tsx
+++ b/src/pages/Timeline.tsx
@@ -1,35 +1,33 @@
 import { Box, Divider, Typography } from "@mui/material";
 import ComposePost from "../components/Posts/ComposePost";
-import { Stack } from "@mui/system";
 import PostList from "../components/Posts/PostList";
+import Layout from "./Layout";
 
 const styles = {
   root: {
+    display: "flex",
+    flexDirection: "column",
     width: "100%",
   },
-  postListContainer: { width: "50%" },
-  timelineHeader: {},
   headerTitle: {
-    alignItems: "center",
-    display: "flex",
     fontWeight: "bold",
-    paddingBottom: 1,
-    paddingLeft: 2,
-    paddingTop: 1,
+    paddingX: 2,
+    paddingY: 1,
   },
 };
 
 const Timeline = () => {
   return (
-    <Stack direction="row" sx={styles.root}>
-      <Box sx={styles.postListContainer}>
-        <Typography sx={styles.headerTitle}>Timeline</Typography>
-        <ComposePost placeholder="What's happening?" />
-        <Divider />
-        <PostList />
-      </Box>
-      <Divider orientation="vertical" />
-    </Stack>
+    <Layout
+      mainContent={
+        <Box sx={styles.root}>
+          <Typography sx={styles.headerTitle}>Timeline</Typography>
+          <ComposePost placeholder="What's happening?" />
+          <Divider />
+          <PostList />
+        </Box>
+      }
+    />
   );
 };
 

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -8,10 +8,6 @@ const styles = {
     flexDirection: "column",
     height: "100%",
     justifyContent: "center",
-    margin: "auto",
-  },
-  loginButton: {
-    borderRadius: 5,
   },
   logo: {
     width: 250,
@@ -38,8 +34,6 @@ const Welcome = () => {
       />
       <Button
         size="large"
-        sx={styles.loginButton}
-        color="primary"
         variant="contained"
         onClick={() => loginWithRedirect()}
       >

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -1,8 +1,3 @@
-.App {
-  display: flex;
-  height: 100%;
-}
-
 html,
 body,
 #root {

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -5,3 +5,7 @@ body,
   margin: 0;
   padding: 0;
 }
+
+html {
+  overflow-y: scroll;
+}

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -1,10 +1,12 @@
-.App,
-#root {
+.App {
+  display: flex;
   height: 100%;
 }
 
 html,
-body {
-  margin: 0;
+body,
+#root {
   height: 100%;
+  margin: 0;
+  padding: 0;
 }


### PR DESCRIPTION
Resolves #58. This PR introduces a new `Layout` component that we should wrap our pages with to keep their layouts consistent. The component accepts two props:
- `middleContent` is usually the main content that's displayed in the middle of the page
- `rightContent` is usually secondary content that's displayed on the right side of the page

`Layout` takes care of layout styling by keeping the navbar, `middleContent` and `rightContent` the same size in all situations

The only pages that don't use `Layout` are `Messages` and `DirectMessages`. Custom layouts were made for the messages pages following the same principles as the others; the only difference is that the middle content is smaller than the right content in these pages