### PR TITLE
T56: Fix expanded post actions styling

### DIFF
--- a/src/components/Posts/ExpandedPostItem.tsx
+++ b/src/components/Posts/ExpandedPostItem.tsx
@@ -211,6 +211,16 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
           justifyContent="space-between"
           sx={styles.cardActions}
         >
+          <IconButton>
+            <RepeatOutlinedIcon />
+          </IconButton>
+          <IconButton
+            onClick={() => {
+              setOpen(true);
+            }}
+          >
+            <AddCommentOutlinedIcon />
+          </IconButton>
           <IconButton
             onClick={() => {
               post.isLikedByCurrentUser
@@ -224,16 +234,6 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
             ) : (
               <FavoriteBorderOutlinedIcon />
             )}
-          </IconButton>
-          <IconButton
-            onClick={() => {
-              setOpen(true);
-            }}
-          >
-            <AddCommentOutlinedIcon />
-          </IconButton>
-          <IconButton>
-            <RepeatOutlinedIcon />
           </IconButton>
           <IconButton>
             <ShareOutlinedIcon />

--- a/src/components/Posts/ExpandedPostItem.tsx
+++ b/src/components/Posts/ExpandedPostItem.tsx
@@ -32,23 +32,16 @@ import { Post } from "../../state/slices/postsSlice";
 
 const styles = {
   actionButton: {
-    fontSize: 14.5,
-    padding: 0,
     color: "black",
     textTransform: "none",
-    fontWeight: "bold",
-    marginRight: 2,
-    display: "flex",
   },
   actionData: {
     display: "flex",
-    paddingTop: 1,
-    paddingBottom: 1,
-    paddingLeft: 1,
+    paddingX: 1,
+    paddingY: 1,
   },
   actionTitles: {
     paddingLeft: 0.5,
-    fontSize: 14.5,
   },
   backButton: {
     backgroundColor: "transparent",
@@ -62,6 +55,7 @@ const styles = {
     width: "100%",
   },
   cardContent: { width: 400 },
+  cardMedia: { maxWidth: 200, margin: "auto" },
   headerTitle: {
     fontWeight: "bold",
   },
@@ -69,14 +63,14 @@ const styles = {
     color: "primary.main",
   },
   timestamp: {
-    paddingLeft: 2,
     fontSize: 14.5,
     color: "#a4a8ab",
   },
   timestampBox: {
     display: "flex",
-    paddingTop: 1,
     paddingBottom: 1,
+    paddingLeft: 2,
+    paddingTop: 1,
   },
   topHeader: {
     display: "flex",
@@ -167,28 +161,48 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
       </CardContent>
       {post.imagePath && (
         <CardMedia
-          sx={{ maxWidth: 200, margin: "auto" }}
+          sx={styles.cardMedia}
           component="img"
           image={post.imagePath}
         />
       )}
       <Box sx={styles.timestampBox}>
-        <Typography component={"span"} sx={styles.timestamp}>
+        <Typography component="span" sx={styles.timestamp}>
           {post.timestamp}
         </Typography>
       </Box>
       <Divider variant="middle" />
       <Box sx={styles.actionData}>
-        <Button sx={styles.actionButton}>
-          {post.numberOfLikes}
-          <Typography sx={styles.actionTitles}>Likes</Typography>
-        </Button>
-        <Button component={"span"} sx={styles.actionButton}>
-          1<Typography sx={styles.actionTitles}>Comments</Typography>
-        </Button>
-        <Button component={"span"} sx={styles.actionButton}>
-          1<Typography sx={styles.actionTitles}>Reposts</Typography>
-        </Button>
+        <Box>
+          <Button fullWidth sx={styles.actionButton}>
+            <Typography component="span" sx={{ fontWeight: "bold" }}>
+              {post.numberOfLikes + 10}
+            </Typography>
+            <Typography component="span" sx={styles.actionTitles}>
+              Likes
+            </Typography>
+          </Button>
+        </Box>
+        <Box>
+          <Button fullWidth sx={styles.actionButton}>
+            <Typography component="span" sx={{ fontWeight: "bold" }}>
+              1
+            </Typography>
+            <Typography component="span" sx={styles.actionTitles}>
+              Comments
+            </Typography>
+          </Button>
+        </Box>
+        <Box>
+          <Button fullWidth sx={styles.actionButton}>
+            <Typography component="span" sx={{ fontWeight: "bold" }}>
+              1
+            </Typography>
+            <Typography component="span" sx={styles.actionTitles}>
+              Reposts
+            </Typography>
+          </Button>
+        </Box>
       </Box>
       <Divider variant="middle" />
       <CardActions>
@@ -226,7 +240,6 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
           </IconButton>
         </Stack>
       </CardActions>
-
       <RepliesModal onClose={() => setOpen(false)} open={open} post={post} />
     </Card>
   );

--- a/src/components/Posts/ExpandedPostItem.tsx
+++ b/src/components/Posts/ExpandedPostItem.tsx
@@ -176,30 +176,30 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
         <Box>
           <Button fullWidth sx={styles.actionButton}>
             <Typography component="span" sx={{ fontWeight: "bold" }}>
-              {post.numberOfLikes + 10}
-            </Typography>
-            <Typography component="span" sx={styles.actionTitles}>
-              Likes
-            </Typography>
-          </Button>
-        </Box>
-        <Box>
-          <Button fullWidth sx={styles.actionButton}>
-            <Typography component="span" sx={{ fontWeight: "bold" }}>
-              1
-            </Typography>
-            <Typography component="span" sx={styles.actionTitles}>
-              Comments
-            </Typography>
-          </Button>
-        </Box>
-        <Box>
-          <Button fullWidth sx={styles.actionButton}>
-            <Typography component="span" sx={{ fontWeight: "bold" }}>
               1
             </Typography>
             <Typography component="span" sx={styles.actionTitles}>
               Reposts
+            </Typography>
+          </Button>
+        </Box>
+        <Box>
+          <Button fullWidth sx={styles.actionButton}>
+            <Typography component="span" sx={{ fontWeight: "bold" }}>
+              1
+            </Typography>
+            <Typography component="span" sx={styles.actionTitles}>
+              Replies
+            </Typography>
+          </Button>
+        </Box>
+        <Box>
+          <Button fullWidth sx={styles.actionButton}>
+            <Typography component="span" sx={{ fontWeight: "bold" }}>
+              {post.numberOfLikes}
+            </Typography>
+            <Typography component="span" sx={styles.actionTitles}>
+              Likes
             </Typography>
           </Button>
         </Box>

--- a/src/components/Posts/ExpandedPostItem.tsx
+++ b/src/components/Posts/ExpandedPostItem.tsx
@@ -34,12 +34,16 @@ const styles = {
   actionButton: {
     color: "black",
     textTransform: "none",
+    "&:hover": {
+      backgroundColor: "transparent",
+    },
   },
-  actionData: {
+  actionsContainer: {
     display: "flex",
     paddingX: 1,
     paddingY: 1,
   },
+  actionCount: { fontWeight: "bold" },
   actionTitles: {
     paddingLeft: 0.5,
   },
@@ -65,9 +69,8 @@ const styles = {
   },
   timestampBox: {
     display: "flex",
-    paddingBottom: 1,
     paddingLeft: 2,
-    paddingTop: 1,
+    paddingY: 1,
   },
   topHeader: {
     display: "flex",
@@ -169,10 +172,10 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
         </Typography>
       </Box>
       <Divider variant="middle" />
-      <Box sx={styles.actionData}>
+      <Box sx={styles.actionsContainer}>
         <Box>
           <Button fullWidth sx={styles.actionButton}>
-            <Typography component="span" sx={{ fontWeight: "bold" }}>
+            <Typography component="span" sx={styles.actionCount}>
               1
             </Typography>
             <Typography component="span" sx={styles.actionTitles}>
@@ -182,7 +185,7 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
         </Box>
         <Box>
           <Button fullWidth sx={styles.actionButton}>
-            <Typography component="span" sx={{ fontWeight: "bold" }}>
+            <Typography component="span" sx={styles.actionCount}>
               1
             </Typography>
             <Typography component="span" sx={styles.actionTitles}>
@@ -192,7 +195,7 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
         </Box>
         <Box>
           <Button fullWidth sx={styles.actionButton}>
-            <Typography component="span" sx={{ fontWeight: "bold" }}>
+            <Typography component="span" sx={styles.actionCount}>
               {post.numberOfLikes}
             </Typography>
             <Typography component="span" sx={styles.actionTitles}>

--- a/src/components/Posts/PostItem.tsx
+++ b/src/components/Posts/PostItem.tsx
@@ -1,10 +1,9 @@
 import {
+  Box,
   Button,
   Card,
   CardActionArea,
   CardContent,
-  Divider,
-  Stack,
   Typography,
 } from "@mui/material";
 import Avatar from "@mui/material/Avatar/Avatar";
@@ -35,6 +34,8 @@ const styles = {
     boxShadow: "none",
   },
   cardActions: {
+    display: "flex",
+    justifyContent: "space-between",
     width: "100%",
   },
   cardContent: { width: 400 },
@@ -118,11 +119,19 @@ const PostItem = ({ post }: PostProps) => {
         )}
       </CardActionArea>
       <CardActions>
-        <Stack
-          direction="row"
-          justifyContent="space-between"
-          sx={styles.cardActions}
-        >
+        <Box sx={styles.cardActions}>
+          <Button startIcon={<RepeatOutlinedIcon />} sx={styles.defaultButton}>
+            1
+          </Button>
+          <Button
+            onClick={() => {
+              setOpen(true);
+            }}
+            startIcon={<AddCommentOutlinedIcon />}
+            sx={styles.defaultButton}
+          >
+            1
+          </Button>
           <Button
             onClick={() => {
               post.isLikedByCurrentUser
@@ -144,23 +153,9 @@ const PostItem = ({ post }: PostProps) => {
           >
             {post.numberOfLikes}
           </Button>
-          <Button
-            onClick={() => {
-              setOpen(true);
-            }}
-            startIcon={<AddCommentOutlinedIcon />}
-            sx={styles.defaultButton}
-          >
-            1
-          </Button>
-          <Button startIcon={<RepeatOutlinedIcon />} sx={styles.defaultButton}>
-            1
-          </Button>
           <Button startIcon={<ShareOutlinedIcon />} sx={styles.defaultButton} />
-        </Stack>
+        </Box>
       </CardActions>
-      <Divider light />
-
       <RepliesModal onClose={() => setOpen(false)} open={open} post={post} />
     </Card>
   );

--- a/src/components/Posts/PostList.tsx
+++ b/src/components/Posts/PostList.tsx
@@ -3,6 +3,7 @@ import PostItem from "./PostItem";
 import axios from "axios";
 import { useAppDispatch, useAppSelector } from "../../state/hooks";
 import { Post, setPosts } from "../../state/slices/postsSlice";
+import { Divider, Stack } from "@mui/material";
 
 const PostList = () => {
   const posts = useAppSelector((state) => state.posts);
@@ -26,13 +27,13 @@ const PostList = () => {
   }, [dispatch, user]);
 
   return (
-    <>
+    <Stack divider={<Divider />}>
       {posts
         .filter((o) => o.parentPostId == null)
         .map((o) => (
           <PostItem key={o.postId} post={o} />
         ))}
-    </>
+    </Stack>
   );
 };
 


### PR DESCRIPTION
Resolves #56. These changes were made to clean up the look of the expanded post actions

Before, when the numbers beside the action buttons changed, the individual text (ex. "likes") beside the number would all shift. This has been changed so that the whole button shifts rather than the individual text

The action buttons and corresponding icons were also reordered. Buttons are now ordered from most likely to be used to less likely to be used to minimize shifting