### PR TITLE
T91, T92, T96: Standardize typography

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "twitter-frontend",
+  "name": "chirp-frontend",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "twitter-frontend",
+      "name": "chirp-frontend",
       "version": "0.1.0",
       "dependencies": {
         "@auth0/auth0-react": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "twitter-frontend",
+  "name": "chirp-frontend",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/src/components/Common/FollowButton.tsx
+++ b/src/components/Common/FollowButton.tsx
@@ -7,7 +7,6 @@ const styles = {
     boxShadow: "none",
     fontWeight: "bold",
     minWidth: "84px",
-    textTransform: "none",
     "&:hover": {
       boxShadow: "none",
     },

--- a/src/components/Common/FollowingButton.tsx
+++ b/src/components/Common/FollowingButton.tsx
@@ -11,7 +11,6 @@ const styles = {
     color: "primary.main",
     fontWeight: "bold",
     minWidth: "84px",
-    textTransform: "none",
     "&:hover": {
       boxShadow: "none",
       backgroundColor: "white.main",

--- a/src/components/Messages/ConversationList.tsx
+++ b/src/components/Messages/ConversationList.tsx
@@ -14,10 +14,12 @@ import CreateMessageModal from "./CreateMessageModal/CreateMessageModal";
 
 const styles = {
   header: {
+    alignItems: "center",
     display: "flex",
     justifyContent: "space-between",
-    paddingTop: 2,
-    paddingX: 2,
+    paddingTop: 1,
+    paddingLeft: 2,
+    paddingRight: 1,
   },
   searchBarContainer: { padding: 1 },
 };
@@ -46,7 +48,7 @@ const ConversationList = () => {
   return (
     <Box>
       <Box sx={styles.header}>
-        <Typography variant="h6">Messages</Typography>
+        <Typography variant="h2">Messages</Typography>
         <IconButton onClick={() => showMessageModal(true)}>
           <ChatOutlinedIcon />
         </IconButton>

--- a/src/components/Messages/ConversationListItem.tsx
+++ b/src/components/Messages/ConversationListItem.tsx
@@ -14,18 +14,23 @@ const styles = {
   avatar: { margin: "auto" },
   displayName: {
     flex: "1, 1, auto",
+    lineHeight: "inherit",
     minWidth: 0,
-    fontWeight: "bold",
   },
   primaryTextContainer: {
     display: "flex",
+    lineHeight: "1.25rem",
     gap: 0.5,
   },
   stack: {
     width: "100%",
   },
-  timestamp: { flex: "1, 0, auto", minWidth: "fit-content" },
-  username: { flex: "1, 1, auto", minWidth: 0 },
+  timestamp: {
+    flex: "1, 0, auto",
+    lineHeight: "inherit",
+    minWidth: "fit-content",
+  },
+  username: { flex: "1, 1, auto", lineHeight: "inherit", minWidth: 0 },
 };
 
 type ConversationListItemProps = {
@@ -52,19 +57,19 @@ const ConversationListItem = ({
           disableTypography
           primary={
             <Box sx={styles.primaryTextContainer}>
-              <Typography noWrap sx={styles.displayName} variant="body2">
+              <Typography noWrap sx={styles.displayName} variant="subtitle1">
                 {conversation.displayName}
               </Typography>
-              <Typography noWrap sx={styles.username} variant="body2">
+              <Typography noWrap sx={styles.username} variant="subtitle2">
                 {`@${conversation.username}`}
               </Typography>
-              <Typography noWrap sx={styles.timestamp} variant="body2">
+              <Typography noWrap sx={styles.timestamp} variant="subtitle2">
                 {`- ${formatTimestamp(conversation.timestamp)}`}
               </Typography>
             </Box>
           }
           secondary={
-            <Typography noWrap variant="body2">
+            <Typography noWrap variant="body1">
               {conversation.textContent}
             </Typography>
           }

--- a/src/components/Messages/ConversationListItem.tsx
+++ b/src/components/Messages/ConversationListItem.tsx
@@ -14,12 +14,10 @@ const styles = {
   avatar: { margin: "auto" },
   displayName: {
     flex: "1, 1, auto",
-    lineHeight: "inherit",
     minWidth: 0,
   },
   primaryTextContainer: {
     display: "flex",
-    lineHeight: "1.25rem",
     gap: 0.5,
   },
   stack: {
@@ -27,10 +25,10 @@ const styles = {
   },
   timestamp: {
     flex: "1, 0, auto",
-    lineHeight: "inherit",
+    fontSize: 15,
     minWidth: "fit-content",
   },
-  username: { flex: "1, 1, auto", lineHeight: "inherit", minWidth: 0 },
+  username: { flex: "1, 1, auto", fontSize: 15, minWidth: 0 },
 };
 
 type ConversationListItemProps = {

--- a/src/components/Messages/CreateMessageModal/CreateMessageModal.tsx
+++ b/src/components/Messages/CreateMessageModal/CreateMessageModal.tsx
@@ -4,7 +4,6 @@ import {
   DialogContent,
   IconButton,
   Typography,
-  Box,
 } from "@mui/material/";
 import CloseIcon from "@mui/icons-material/Close";
 import MessagesModalList from "./MessagesModalList";
@@ -21,11 +20,9 @@ const styles = {
   dialogTitle: {
     display: "flex",
     alignItems: "center",
+    paddingY: 1,
   },
-  headerTitle: {
-    fontWeight: "bold",
-  },
-  titleBox: { paddingLeft: 3, width: "100%" },
+  titleText: { paddingLeft: 3 },
 };
 
 type CreateMessageModalProps = {
@@ -58,9 +55,9 @@ export default function CreateMessageModal({
         <IconButton onClick={onClose}>
           <CloseIcon />
         </IconButton>
-        <Box sx={styles.titleBox}>
-          <Typography sx={styles.headerTitle}>New Message</Typography>
-        </Box>
+        <Typography variant="h3" sx={styles.titleText}>
+          New Message
+        </Typography>
       </DialogTitle>
       <MessagesSearchBar
         placeholder="Search following"

--- a/src/components/Messages/CreateMessageModal/MessagesModalListItem.tsx
+++ b/src/components/Messages/CreateMessageModal/MessagesModalListItem.tsx
@@ -12,9 +12,6 @@ import { SelectedUser } from "../../../state/slices/messagesSlice";
 
 const styles = {
   avatar: { margin: "auto" },
-  displayName: {
-    fontWeight: "bold",
-  },
   primaryTextContainer: {
     gap: 0.5,
     width: "30%",
@@ -54,10 +51,10 @@ const MessageModalListItem = ({
           disableTypography
           primary={
             <Box>
-              <Typography sx={styles.displayName} variant="body2">
+              <Typography variant="subtitle1">
                 {otherUser.displayName}
               </Typography>
-              <Typography variant="body2">{`@${otherUser.username}`}</Typography>
+              <Typography variant="subtitle2">{`@${otherUser.username}`}</Typography>
             </Box>
           }
         />

--- a/src/components/Messages/CreateMessageModal/MessagesSearchBar.tsx
+++ b/src/components/Messages/CreateMessageModal/MessagesSearchBar.tsx
@@ -23,9 +23,6 @@ const styles = {
     paddingTop: 0,
     paddingX: 2,
   },
-  displayName: {
-    fontWeight: "bold",
-  },
   searchIcon: { paddingRight: 0 },
 };
 
@@ -105,10 +102,10 @@ const MessagesSearchBar = ({
                 disableTypography
                 primary={
                   <Box>
-                    <Typography sx={styles.displayName} variant="body2">
+                    <Typography variant="subtitle1">
                       {option.displayName}
                     </Typography>
-                    <Typography variant="body2">{`@${option.username}`}</Typography>
+                    <Typography variant="subtitle2">{`@${option.username}`}</Typography>
                   </Box>
                 }
               />

--- a/src/components/NavBar/AccountMenu.tsx
+++ b/src/components/NavBar/AccountMenu.tsx
@@ -39,8 +39,13 @@ const AccountMenu = () => {
       <Button onClick={handleClick} sx={styles.button}>
         <Avatar />
         <Stack sx={styles.nameContainer}>
-          <Typography>{user.displayName}</Typography>
-          <Typography>{`@${user.username}`}</Typography>
+          <Typography color="primary" variant="subtitle1" fontSize={15}>
+            {user.displayName}
+          </Typography>
+          <Typography
+            color="primary"
+            variant="subtitle2"
+          >{`@${user.username}`}</Typography>
         </Stack>
       </Button>
       <Popover

--- a/src/components/NavBar/AccountMenu.tsx
+++ b/src/components/NavBar/AccountMenu.tsx
@@ -39,7 +39,7 @@ const AccountMenu = () => {
       <Button onClick={handleClick} sx={styles.button}>
         <Avatar />
         <Stack sx={styles.nameContainer}>
-          <Typography color="primary" variant="subtitle1" fontSize={15}>
+          <Typography color="primary" variant="subtitle1">
             {user.displayName}
           </Typography>
           <Typography

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -24,7 +24,7 @@ const styles = {
     marginBottom: "auto",
     width: "100%",
   },
-  postButton: { margin: 2 },
+  postButton: { fontSize: 18, margin: 2 },
   toolbar: {
     height: "100%",
     marginLeft: "auto",

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -10,6 +10,10 @@ import ComposePost from "../Posts/ComposePost";
 import { useAppSelector } from "../../state/hooks";
 
 const styles = {
+  icon: {
+    color: "black.main",
+    opacity: 0.8,
+  },
   logo: {
     alignSelf: "left",
     height: 50,
@@ -38,19 +42,19 @@ const NavBar = () => {
 
   const navItems = [
     {
-      icon: <HomeIcon />,
+      icon: <HomeIcon sx={styles.icon} />,
       label: "Home",
       route: "/",
     },
     {
-      icon: <MailIcon />,
+      icon: <MailIcon sx={styles.icon} />,
       label: "Messages",
       route: selectedConversation.userId
         ? `/messages/${user.userId}/${selectedConversation.userId}`
         : "/messages",
     },
     {
-      icon: <AccountCircleIcon />,
+      icon: <AccountCircleIcon sx={styles.icon} />,
       label: "Profile",
       route: `/${user.username}`,
     },

--- a/src/components/NavBar/NavItem.tsx
+++ b/src/components/NavBar/NavItem.tsx
@@ -12,7 +12,10 @@ const NavItem = ({ icon, label, route }: NavItemProps) => {
   return (
     <ListItemButton component={Routerlink} to={route}>
       <ListItemIcon>{icon}</ListItemIcon>
-      <ListItemText primary={label} />
+      <ListItemText
+        primary={label}
+        primaryTypographyProps={{ variant: "h3" }}
+      />
     </ListItemButton>
   );
 };

--- a/src/components/Posts/ExpandedPostItem.tsx
+++ b/src/components/Posts/ExpandedPostItem.tsx
@@ -54,7 +54,6 @@ const styles = {
   cardActions: {
     width: "100%",
   },
-  cardContent: { width: 400 },
   cardMedia: { maxWidth: 200, margin: "auto" },
   headerTitle: {
     fontWeight: "bold",
@@ -62,7 +61,6 @@ const styles = {
   likedIcon: {
     color: "primary.main",
   },
-  nameText: { lineHeight: "inherit" },
   timestampBox: {
     display: "flex",
     paddingLeft: 2,
@@ -123,7 +121,6 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
           <Link
             color={theme.typography.subtitle1.color}
             component={Routerlink}
-            sx={styles.nameText}
             to={`/${post.username}`}
             underline="hover"
             variant="subtitle1"
@@ -135,7 +132,6 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
           <Link
             color={theme.typography.subtitle2.color}
             component={Routerlink}
-            sx={styles.nameText}
             to={`/${post.username}`}
             underline="none"
             variant="subtitle2"
@@ -144,7 +140,7 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
           </Link>
         }
       />
-      <CardContent sx={styles.cardContent}>
+      <CardContent>
         <Typography>{post.textContent}</Typography>
       </CardContent>
       {post.imagePath && (

--- a/src/components/Posts/ExpandedPostItem.tsx
+++ b/src/components/Posts/ExpandedPostItem.tsx
@@ -31,10 +31,11 @@ import { Post } from "../../state/slices/postsSlice";
 import { toggleLikePostRequest } from "../../utilities/postUtilities";
 import { Link as Routerlink } from "react-router-dom";
 import UserAvatar from "../Common/UserAvatar";
+import { useTheme } from "@mui/material/styles";
 
 const styles = {
   actionButton: {
-    color: "black",
+    color: "black.main",
     "&:hover": {
       backgroundColor: "transparent",
     },
@@ -44,8 +45,7 @@ const styles = {
     paddingX: 1,
     paddingY: 1,
   },
-  actionCount: { fontWeight: "bold", fontSize: 14.5, paddingRight: 0.5 },
-  actionText: { fontSize: 14.5 },
+  actionCount: { fontWeight: "bold", paddingRight: 0.5 },
   backButton: { "&:hover": { backgroundColor: "transparent" } },
   card: {
     padding: 0,
@@ -56,34 +56,22 @@ const styles = {
   },
   cardContent: { width: 400 },
   cardMedia: { maxWidth: 200, margin: "auto" },
-  displayName: {
-    fontSize: 15,
-    fontWeight: "bold",
-    color: "black",
-    paddingRight: 0.5,
-  },
   headerTitle: {
     fontWeight: "bold",
   },
   likedIcon: {
     color: "primary.main",
   },
-  timestamp: {
-    fontSize: 14.5,
-    color: "#a4a8ab",
-  },
+  nameText: { lineHeight: "inherit" },
   timestampBox: {
     display: "flex",
     paddingLeft: 2,
     paddingY: 1,
   },
   topHeader: {
-    display: "flex",
     alignItems: "center",
-  },
-  username: {
-    fontSize: "inherit",
-    color: "grey",
+    display: "flex",
+    paddingTop: 1,
   },
 };
 
@@ -92,6 +80,7 @@ type ExpandedPostItemProps = {
 };
 
 const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
+  const theme = useTheme();
   const dispatch = useAppDispatch();
   const user = useAppSelector((state) => state.user);
   const urlParams = useParams();
@@ -117,11 +106,11 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
 
   return (
     <Card sx={styles.card}>
-      <Box style={styles.topHeader}>
+      <Box sx={styles.topHeader}>
         <IconButton onClick={() => navigate(-1)} sx={styles.backButton}>
           <KeyboardBackspaceIcon color="secondary" />
         </IconButton>
-        <Typography style={styles.headerTitle}>Post</Typography>
+        <Typography variant="h2">Post</Typography>
       </Box>
       <CardHeader
         avatar={<UserAvatar username={post.username} />}
@@ -132,20 +121,24 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
         }
         title={
           <Link
+            color={theme.typography.subtitle1.color}
             component={Routerlink}
+            sx={styles.nameText}
             to={`/${post.username}`}
             underline="hover"
-            sx={styles.displayName}
+            variant="subtitle1"
           >
             {post.displayName}
           </Link>
         }
         subheader={
           <Link
+            color={theme.typography.subtitle2.color}
             component={Routerlink}
+            sx={styles.nameText}
             to={`/${post.username}`}
             underline="none"
-            sx={styles.username}
+            variant="subtitle2"
           >
             @{post.username}
           </Link>
@@ -162,7 +155,7 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
         />
       )}
       <Box sx={styles.timestampBox}>
-        <Typography component="span" sx={styles.timestamp}>
+        <Typography component="span" variant="subtitle2">
           {formatTimestamp(post.timestamp)}
         </Typography>
       </Box>
@@ -173,9 +166,7 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
             <Typography component="span" sx={styles.actionCount}>
               {post.numberOfReposts}
             </Typography>
-            <Typography component="span" sx={styles.actionText}>
-              Reposts
-            </Typography>
+            <Typography component="span">Reposts</Typography>
           </Button>
         </Box>
         <Box>
@@ -183,9 +174,7 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
             <Typography component="span" sx={styles.actionCount}>
               {post.numberOfReplies}
             </Typography>
-            <Typography component="span" sx={styles.actionText}>
-              Replies
-            </Typography>
+            <Typography component="span">Replies</Typography>
           </Button>
         </Box>
         <Box>
@@ -193,9 +182,7 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
             <Typography component="span" sx={styles.actionCount}>
               {post.numberOfLikes}
             </Typography>
-            <Typography component="span" sx={styles.actionText}>
-              Likes
-            </Typography>
+            <Typography component="span">Likes</Typography>
           </Button>
         </Box>
       </Box>

--- a/src/components/Posts/ExpandedPostItem.tsx
+++ b/src/components/Posts/ExpandedPostItem.tsx
@@ -35,7 +35,6 @@ import UserAvatar from "../Common/UserAvatar";
 const styles = {
   actionButton: {
     color: "black",
-    textTransform: "none",
     "&:hover": {
       backgroundColor: "transparent",
     },

--- a/src/components/Posts/PostItem.tsx
+++ b/src/components/Posts/PostItem.tsx
@@ -156,7 +156,9 @@ const PostItem = ({ post }: PostProps) => {
           >
             {post.numberOfLikes}
           </Button>
-          <Button startIcon={<ShareOutlinedIcon />} sx={styles.defaultButton} />
+          <IconButton>
+            <ShareOutlinedIcon />
+          </IconButton>
         </Box>
       </CardActions>
       <RepliesModal onClose={() => setOpen(false)} open={open} post={post} />

--- a/src/components/Posts/PostItem.tsx
+++ b/src/components/Posts/PostItem.tsx
@@ -42,7 +42,6 @@ const styles = {
     justifyContent: "space-between",
     width: "100%",
   },
-  cardContent: { width: 400 },
   coloredButton: {
     color: "primary.main",
   },
@@ -106,7 +105,7 @@ const PostItem = ({ post }: PostProps) => {
         subheaderTypographyProps={{ color: theme.typography.subtitle2.color }}
       />
       <CardActionArea onClick={() => routeChange()}>
-        <CardContent sx={styles.cardContent}>
+        <CardContent>
           <Typography>{post.textContent}</Typography>
         </CardContent>
         {post.imagePath && (

--- a/src/components/Posts/PostItem.tsx
+++ b/src/components/Posts/PostItem.tsx
@@ -6,6 +6,7 @@ import {
   CardContent,
   Link,
   Typography,
+  useTheme,
 } from "@mui/material";
 import CardHeader from "@mui/material/CardHeader/CardHeader";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
@@ -52,18 +53,12 @@ const styles = {
     },
   },
   displayName: {
-    fontSize: 15,
-    fontWeight: "bold",
-    color: "black",
     paddingRight: 0.5,
-  },
-  username: {
-    fontSize: "inherit",
-    color: "grey",
   },
 };
 
 const PostItem = ({ post }: PostProps) => {
+  const theme = useTheme();
   const dispatch = useAppDispatch();
   const user = useAppSelector((state) => state.user);
   const [open, setOpen] = useState(false);
@@ -87,24 +82,28 @@ const PostItem = ({ post }: PostProps) => {
         title={
           <Box>
             <Link
+              color={theme.typography.subtitle1.color}
               component={Routerlink}
               to={`/${post.username}`}
               underline="hover"
               sx={styles.displayName}
+              variant="subtitle1"
             >
               {post.displayName}
             </Link>
             <Link
+              color={theme.typography.subtitle2.color}
               component={Routerlink}
               to={`/${post.username}`}
               underline="none"
-              sx={styles.username}
+              variant="subtitle2"
             >
               @{post.username}
             </Link>
           </Box>
         }
         subheader={formatTimestamp(post.timestamp)}
+        subheaderTypographyProps={{ color: theme.typography.subtitle2.color }}
       />
       <CardActionArea onClick={() => routeChange()}>
         <CardContent sx={styles.cardContent}>

--- a/src/components/Posts/RepliesModal.tsx
+++ b/src/components/Posts/RepliesModal.tsx
@@ -29,14 +29,10 @@ const styles = {
     flexDirection: "column",
     gap: 0.25,
   },
-  card: {
-    padding: 0,
-    boxShadow: "none",
-  },
+  card: { paddingX: 1 },
   cardContent: {
     padding: 0,
     display: "flex",
-    flexDirection: "column",
   },
   cardMedia: { maxWidth: 200, margin: "auto" },
   dialog: {
@@ -57,22 +53,14 @@ const styles = {
     flex: 1,
     paddingBottom: 1,
   },
-  mainContainer: {
-    display: "flex",
-  },
-  moreButton: { paddingY: 0 },
-  names: {
-    display: "flex",
-  },
+  moreButton: { padding: 0.5 },
   namesAndOption: {
     width: "100%",
     display: "flex",
     justifyContent: "space-between",
     alignItems: "center",
   },
-  postContentContainer: {
-    display: "flex",
-    flexDirection: "column",
+  postContent: {
     paddingRight: 3,
   },
   replyingText: {
@@ -81,12 +69,12 @@ const styles = {
   },
   replyingTo: {
     fontSize: 14,
+    paddingTop: 0.5,
   },
   textContent: {
     flex: "0 0 88%",
     display: "flex",
     flexDirection: "column",
-    gap: 0.5,
   },
   username: { fontSize: 14 },
 };
@@ -114,44 +102,35 @@ export const RepliesModal = ({ onClose, open, post }: PostModalProps) => {
       <DialogContent sx={styles.dialogContent}>
         <Card sx={styles.card}>
           <CardContent sx={styles.cardContent}>
-            <Box sx={styles.mainContainer}>
-              <Box sx={styles.avatarLineContainer}>
-                <Box sx={styles.avatarBox}>
-                  <UserAvatar username={post.username} />
-                </Box>
-                <Box sx={styles.lineBox}>
-                  <Divider orientation="vertical" sx={styles.line} />
-                </Box>
+            <Box sx={styles.avatarLineContainer}>
+              <Box sx={styles.avatarBox}>
+                <UserAvatar username={post.username} />
               </Box>
-              <Box sx={styles.textContent}>
-                <Box sx={styles.namesAndOption}>
-                  <Box sx={styles.names}>
-                    <Typography sx={styles.displayName}>
-                      {`${post.displayName} `}
-                      <Typography
-                        component="span"
-                        sx={styles.username}
-                      >{`@${post.username}`}</Typography>
-                    </Typography>
-                  </Box>
-                  <IconButton sx={styles.moreButton}>
-                    <MoreVertIcon />
-                  </IconButton>
-                </Box>
-                <Box sx={styles.postContentContainer}>
-                  <Typography>{post.textContent}</Typography>
-                </Box>
-                <Box sx={styles.replyingText}>
-                  <Typography variant="subtitle1" sx={styles.replyingTo}>
-                    {`Replying to `}
-                    <Typography
-                      component="span"
-                      color="primary"
-                      sx={styles.author}
-                    >{`@${post.username}`}</Typography>
+              <Box sx={styles.lineBox}>
+                <Divider orientation="vertical" sx={styles.line} />
+              </Box>
+            </Box>
+            <Box sx={styles.textContent}>
+              <Box sx={styles.namesAndOption}>
+                <Typography sx={styles.displayName}>
+                  {post.displayName}
+                  <Typography component="span" sx={styles.username}>
+                    {` @${post.username}`}
                   </Typography>
-                </Box>
+                </Typography>
+                <IconButton size="small" sx={styles.moreButton}>
+                  <MoreVertIcon />
+                </IconButton>
               </Box>
+              <Typography sx={styles.postContent}>
+                {post.textContent}
+              </Typography>
+              <Typography variant="subtitle1" sx={styles.replyingTo}>
+                Replying to
+                <Typography component="span" color="primary" sx={styles.author}>
+                  {` @${post.username}`}
+                </Typography>
+              </Typography>
             </Box>
           </CardContent>
           {post.imagePath && (

--- a/src/components/Posts/RepliesModal.tsx
+++ b/src/components/Posts/RepliesModal.tsx
@@ -17,7 +17,6 @@ import ComposeReply from "./ComposeReply";
 import UserAvatar from "../Common/UserAvatar";
 
 const styles = {
-  author: { fontSize: 14 },
   avatarBox: {
     display: "flex",
     justifyContent: "center",
@@ -42,7 +41,6 @@ const styles = {
     alignItems: "center",
     justifyContent: "center",
   },
-  displayName: { fontSize: 14, fontWeight: "bold" },
   line: {
     borderRightWidth: "3px",
   },
@@ -62,21 +60,13 @@ const styles = {
   },
   postContent: {
     paddingRight: 3,
-  },
-  replyingText: {
-    display: "flex",
-    alignItems: "center",
-  },
-  replyingTo: {
-    fontSize: 14,
-    paddingTop: 0.5,
+    paddingBottom: 0.5,
   },
   textContent: {
     flex: "0 0 88%",
     display: "flex",
     flexDirection: "column",
   },
-  username: { fontSize: 14 },
 };
 
 type PostModalProps = {
@@ -112,9 +102,9 @@ export const RepliesModal = ({ onClose, open, post }: PostModalProps) => {
             </Box>
             <Box sx={styles.textContent}>
               <Box sx={styles.namesAndOption}>
-                <Typography sx={styles.displayName}>
+                <Typography variant="subtitle1">
                   {post.displayName}
-                  <Typography component="span" sx={styles.username}>
+                  <Typography component="span" variant="subtitle2">
                     {` @${post.username}`}
                   </Typography>
                 </Typography>
@@ -125,9 +115,9 @@ export const RepliesModal = ({ onClose, open, post }: PostModalProps) => {
               <Typography sx={styles.postContent}>
                 {post.textContent}
               </Typography>
-              <Typography variant="subtitle1" sx={styles.replyingTo}>
+              <Typography>
                 Replying to
-                <Typography component="span" color="primary" sx={styles.author}>
+                <Typography component="span" color="primary">
                   {` @${post.username}`}
                 </Typography>
               </Typography>

--- a/src/components/SideBar/RelevantUsers.tsx
+++ b/src/components/SideBar/RelevantUsers.tsx
@@ -5,6 +5,7 @@ import {
   ListItemButton,
   ListItemText,
   Typography,
+  useTheme,
 } from "@mui/material";
 import { useAppDispatch, useAppSelector } from "../../state/hooks";
 import { useNavigate, Link as Routerlink } from "react-router-dom";
@@ -25,24 +26,12 @@ const styles = {
     width: "100%",
     overflow: "hidden",
   },
-  displayName: {
-    fontWeight: "bold",
-    color: "black",
-    fontSize: "0.875rem",
-  },
   listItemText: { marginY: 0.5 },
-  title: {
-    fontWeight: "bold",
-    paddingX: 2,
-    paddingY: 1,
-  },
-  username: {
-    color: "rgba(0, 0, 0, 0.6)",
-    fontSize: "0.875rem",
-  },
+  title: { fontWeight: "bold", paddingX: 2, paddingY: 1 },
 };
 
 const RelevantUsers = () => {
+  const theme = useTheme();
   const relevantUser = useAppSelector((state) => state.posts.expandedPost);
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
@@ -59,24 +48,27 @@ const RelevantUsers = () => {
         <ListItemText
           primary={
             <Link
-              color="inherit"
+              color={theme.typography.subtitle1.color}
               component={Routerlink}
               to={`/${relevantUser.username}`}
               underline="hover"
+              variant="subtitle1"
             >
-              <Typography component="span" sx={styles.displayName}>
-                {relevantUser.displayName}
-              </Typography>
+              {relevantUser.displayName}
             </Link>
           }
           secondary={
             <Typography
+              color={theme.typography.subtitle2.color}
               component="span"
-              sx={styles.username}
-            >{`@${relevantUser.username}`}</Typography>
+              variant="subtitle2"
+            >
+              {`@${relevantUser.username}`}
+            </Typography>
           }
           sx={styles.listItemText}
         />
+        {/* TODO: Remove this if the post is by the current user */}
         {relevantUser.followStatus ? (
           <FollowingButton
             onClick={() => dispatch(toggleFollow(false))}

--- a/src/components/SideBar/SidebarFooter.tsx
+++ b/src/components/SideBar/SidebarFooter.tsx
@@ -69,17 +69,6 @@ const SidebarFooter = () => {
       >
         GitHub
       </Link>
-      <Link
-        color={theme.typography.body2.color}
-        component={Routerlink}
-        sx={styles.footerText}
-        target="_blank"
-        to="/coming-soon"
-        underline="hover"
-        variant="body2"
-      >
-        Docs
-      </Link>
     </Box>
   );
 };

--- a/src/components/SideBar/SidebarFooter.tsx
+++ b/src/components/SideBar/SidebarFooter.tsx
@@ -1,10 +1,8 @@
-import { Box, Link } from "@mui/material";
+import { Box, Link, useTheme } from "@mui/material";
 import { Link as Routerlink } from "react-router-dom";
 
 const styles = {
   footerText: {
-    color: "gray.main",
-    fontSize: 12,
     paddingRight: 1.5,
   },
   footerNav: {
@@ -14,64 +12,71 @@ const styles = {
 };
 
 const SidebarFooter = () => {
+  const theme = useTheme();
   return (
     <Box component="nav" sx={styles.footerNav}>
       <Link
+        color={theme.typography.body2.color}
         component={Routerlink}
         sx={styles.footerText}
         target="_blank"
         to="/coming-soon"
         underline="hover"
-        variant="subtitle2"
+        variant="body2"
       >
         Terms of Service
       </Link>
       <Link
+        color={theme.typography.body2.color}
         component={Routerlink}
         sx={styles.footerText}
         target="_blank"
         to="/coming-soon"
         underline="hover"
-        variant="subtitle2"
+        variant="body2"
       >
         Privacy Policy
       </Link>
       <Link
+        color={theme.typography.body2.color}
         component={Routerlink}
         sx={styles.footerText}
         target="_blank"
         to="/coming-soon"
         underline="hover"
-        variant="subtitle2"
+        variant="body2"
       >
         Contact Us
       </Link>
       <Link
+        color={theme.typography.body2.color}
         component={Routerlink}
         sx={styles.footerText}
         target="_blank"
         to="/coming-soon"
         underline="hover"
-        variant="subtitle2"
+        variant="body2"
       >
         About The Team
       </Link>
       <Link
+        color={theme.typography.body2.color}
         href="https://github.com/Project-Chirp"
         sx={styles.footerText}
         target="_blank"
         underline="hover"
-        variant="subtitle2"
+        variant="body2"
       >
         GitHub
       </Link>
       <Link
+        color={theme.typography.body2.color}
         component={Routerlink}
         sx={styles.footerText}
         target="_blank"
         to="/coming-soon"
         underline="hover"
-        variant="subtitle2"
+        variant="body2"
       >
         Docs
       </Link>

--- a/src/components/SideBar/SuggestedUsers.tsx
+++ b/src/components/SideBar/SuggestedUsers.tsx
@@ -1,5 +1,4 @@
 import {
-  Avatar,
   List,
   ListItemButton,
   ListItemAvatar,
@@ -7,19 +6,13 @@ import {
   Box,
   Typography,
   Link,
+  useTheme,
 } from "@mui/material";
 import { useNavigate, Link as Routerlink } from "react-router-dom";
 import FollowButton from "../Common/FollowButton";
-import { useAppDispatch } from "../../state/hooks";
-import { toggleFollow } from "../../state/slices/postsSlice";
+import UserAvatar from "../Common/UserAvatar";
 
 const styles = {
-  avatar: {
-    opacity: 0.75,
-    "&:hover": {
-      opacity: 1,
-    },
-  },
   container: {
     boxSizing: "border-box",
     border: "2px solid",
@@ -31,17 +24,8 @@ const styles = {
     width: "100%",
     overflow: "hidden",
   },
-  displayName: {
-    color: "black",
-    fontWeight: "bold",
-    fontSize: "0.875rem",
-  },
   listItemText: { marginY: 0.5 },
   title: { fontWeight: "bold", paddingX: 2, paddingY: 1 },
-  username: {
-    color: "rgba(0, 0, 0, 0.7)",
-    fontSize: "0.875rem",
-  },
 };
 
 // TODO: Return followStatus from the follow table as well for every user.
@@ -73,7 +57,7 @@ const usersData = [
 ];
 
 const SuggestedUsers = () => {
-  const dispatch = useAppDispatch();
+  const theme = useTheme();
   const navigate = useNavigate();
 
   return (
@@ -85,33 +69,32 @@ const SuggestedUsers = () => {
         {usersData.map((user) => (
           <ListItemButton key={user.id} onClick={() => navigate(`/`)}>
             <ListItemAvatar>
-              <Avatar
-                alt={user.displayName}
-                component={Routerlink}
-                sx={styles.avatar}
-                to="/"
-              />
+              <UserAvatar username="" />
             </ListItemAvatar>
             <ListItemText
               primary={
                 <Link
+                  color={theme.typography.subtitle1.color}
                   component={Routerlink}
                   to="/"
                   underline="hover"
-                  sx={styles.displayName}
+                  variant="subtitle1"
                 >
                   {user.displayName}
                 </Link>
               }
               secondary={
                 <Typography
+                  color={theme.typography.subtitle2.color}
                   component="span"
-                  sx={styles.username}
-                >{`@${user.username}`}</Typography>
+                  variant="subtitle2"
+                >
+                  {`@${user.username}`}
+                </Typography>
               }
               sx={styles.listItemText}
             />
-            {/* TODO: update to render Following Button as well */}
+            {/* TODO: Update to render Following Button as well */}
             <FollowButton onClick={() => {}} visitedUserId={NaN} />
           </ListItemButton>
         ))}

--- a/src/pages/DirectMessage.tsx
+++ b/src/pages/DirectMessage.tsx
@@ -48,8 +48,10 @@ const styles = {
     flexDirection: "column",
     height: "100%",
   },
+  displayName: { fontWeight: "bold" },
   divider: { height: "auto" },
   headerContainer: {
+    alignItems: "center",
     display: "flex",
     justifyContent: "space-between",
     paddingLeft: 2,
@@ -189,7 +191,7 @@ const DirectMessage = () => {
             <Box sx={styles.headerContent}>
               <UserAvatar username={selectedConversation.username} />
               <Box>
-                <Typography variant="subtitle1">
+                <Typography sx={styles.displayName} variant="subtitle1">
                   {selectedConversation.displayName}
                 </Typography>
                 <Typography variant="subtitle2">{`@${selectedConversation.username}`}</Typography>

--- a/src/pages/DirectMessage.tsx
+++ b/src/pages/DirectMessage.tsx
@@ -25,7 +25,6 @@ import {
   setSelectedConversation,
   updateConversation,
 } from "../state/slices/messagesSlice";
-import theme from "../styles/Theme";
 import NavBar from "../components/NavBar/NavBar";
 import formatTimestamp from "../utilities/formatTimestamp";
 import UserAvatar from "../components/Common/UserAvatar";
@@ -48,7 +47,6 @@ const styles = {
     flexDirection: "column",
     height: "100%",
   },
-  displayName: { fontWeight: "bold" },
   divider: { height: "auto" },
   headerContainer: {
     alignItems: "center",
@@ -67,7 +65,7 @@ const styles = {
   messageText: {
     padding: 1,
     borderRadius: 10,
-    backgroundColor: "#cce3d9",
+    backgroundColor: "primary.light",
   },
   middleContent: { flex: "0 0 350px", height: "100vh", minWidth: 0 },
   nav: { flex: "0 0 275px", height: "100vh", position: "sticky", top: 0 },
@@ -83,7 +81,7 @@ const styles = {
   sentMessageText: {
     padding: 1,
     borderRadius: 10,
-    backgroundColor: theme.palette.primary.main,
+    backgroundColor: "primary.main",
   },
   timestamp: { marginTop: 0.5 },
 };
@@ -191,7 +189,7 @@ const DirectMessage = () => {
             <Box sx={styles.headerContent}>
               <UserAvatar username={selectedConversation.username} />
               <Box>
-                <Typography sx={styles.displayName} variant="subtitle1">
+                <Typography variant="subtitle1">
                   {selectedConversation.displayName}
                 </Typography>
                 <Typography variant="subtitle2">{`@${selectedConversation.username}`}</Typography>
@@ -221,11 +219,11 @@ const DirectMessage = () => {
                             : styles.messageText
                         }
                       >
-                        <Typography variant="body2">{o.textContent}</Typography>
+                        <Typography>{o.textContent}</Typography>
                       </Box>
                     }
                     secondary={
-                      <Typography sx={styles.timestamp} variant="caption">
+                      <Typography sx={styles.timestamp} variant="body2">
                         {formatTimestamp(o.timestamp)}
                       </Typography>
                     }

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -43,7 +43,7 @@ const Messages = () => {
         <Box sx={styles.rightContent}>
           <Box sx={styles.selectMessageContainer}>
             <Box>
-              <Typography variant="h6">Select a Message</Typography>
+              <Typography variant="h1">Select a Message</Typography>
               <Typography>
                 Choose one of your existing conversations or start a new one!
               </Typography>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -50,6 +50,7 @@ const styles = {
     backgroundColor: "primary.main",
   },
   bio: { paddingTop: 1 },
+  displayName: { fontWeight: 700 },
   editProfileButton: {
     fontWeight: "bold",
     color: "black.main",
@@ -63,6 +64,7 @@ const styles = {
   header: {
     alignItems: "center",
     display: "flex",
+    gap: 2,
     padding: 1,
   },
   nameContainer: { paddingTop: 1 },
@@ -223,7 +225,7 @@ const Profile = () => {
                     ))}
                 </Box>
                 <Box sx={styles.nameContainer}>
-                  <Typography variant="h3">
+                  <Typography variant="h3" sx={styles.displayName}>
                     {profileContents.displayName}
                   </Typography>
                   <Typography variant="subtitle2" sx={styles.username}>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -54,7 +54,6 @@ const styles = {
     fontWeight: "bold",
   },
   editProfileButton: {
-    textTransform: "none",
     fontWeight: "bold",
     color: "black",
     minWidth: "84px",
@@ -65,7 +64,6 @@ const styles = {
   followerButtons: {
     color: "black",
     padding: 0,
-    textTransform: "none",
     "&:hover": {
       backgroundColor: "transparent",
     },

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -10,6 +10,7 @@ import {
   Box,
   Divider,
   Link,
+  useTheme,
 } from "@mui/material";
 import EditIcon from "@mui/icons-material/Edit";
 import ProfilePosts from "../components/Profile/ProfilePosts";
@@ -49,23 +50,12 @@ const styles = {
     backgroundColor: "primary.main",
   },
   bio: { paddingTop: 1 },
-  displayName: {
-    fontSize: 20,
-    fontWeight: "bold",
-  },
   editProfileButton: {
     fontWeight: "bold",
-    color: "black",
+    color: "black.main",
     minWidth: "84px",
     ":hover": {
       backgroundColor: "primary.light",
-    },
-  },
-  followerButtons: {
-    color: "black",
-    padding: 0,
-    "&:hover": {
-      backgroundColor: "transparent",
     },
   },
   followerCount: { fontWeight: "bold" },
@@ -73,25 +63,19 @@ const styles = {
   header: {
     alignItems: "center",
     display: "flex",
+    padding: 1,
   },
   nameContainer: { paddingTop: 1 },
   personalInfo: {
     alignItems: "center",
     display: "flex",
-    color: "grey",
+    color: "gray.dark",
     gap: 2,
     paddingTop: 1,
   },
   personalInfoContent: { display: "flex", gap: 0.5 },
   profileContent: { padding: 2 },
-  tabs: {
-    textTransform: "none",
-  },
-  tweetCount: { fontSize: 13 },
-  username: {
-    color: "#71797E",
-    fontSize: 15,
-  },
+  username: { fontSize: 16 },
 };
 
 export type EditableProfileContents = Pick<
@@ -113,6 +97,7 @@ export type ProfileContent = {
 };
 
 const Profile = () => {
+  const theme = useTheme();
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const { username } = useParams();
@@ -183,16 +168,16 @@ const Profile = () => {
       <Layout
         middleContent={
           <Box>
-            <Box style={styles.header}>
+            <Box sx={styles.header}>
               <IconButton onClick={() => navigate(-1)}>
                 <KeyboardBackspaceIcon color="secondary" />
               </IconButton>
               <Box>
-                <Typography sx={styles.displayName}>
+                <Typography variant="h3">
                   {profileContents.displayName}
                 </Typography>
-                <Typography sx={styles.tweetCount}>
-                  {profileContents.postCount} Tweets
+                <Typography variant="subtitle2">
+                  {profileContents.postCount} Posts
                 </Typography>
               </Box>
             </Box>
@@ -238,10 +223,10 @@ const Profile = () => {
                     ))}
                 </Box>
                 <Box sx={styles.nameContainer}>
-                  <Typography variant="h2" sx={styles.displayName}>
+                  <Typography variant="h3">
                     {profileContents.displayName}
                   </Typography>
-                  <Typography variant="h3" sx={styles.username}>
+                  <Typography variant="subtitle2" sx={styles.username}>
                     @{profileContents.username}
                   </Typography>
                 </Box>
@@ -266,10 +251,10 @@ const Profile = () => {
                 </Box>
                 <Box sx={styles.followerContainer}>
                   <Link
+                    color={theme.palette.black.main}
                     component={Routerlink}
                     to={`/${username}`} // TODO: Create Modal to check followers
                     underline="hover"
-                    sx={styles.followerButtons}
                   >
                     <Typography component="span" sx={styles.followerCount}>
                       {profileContents.followerCount}
@@ -277,10 +262,10 @@ const Profile = () => {
                     <Typography component="span"> Followers</Typography>
                   </Link>
                   <Link
+                    color={theme.palette.black.main}
                     component={Routerlink}
                     to={`/${username}`} // TODO: Create Modal to check following
                     underline="hover"
-                    sx={styles.followerButtons}
                   >
                     <Typography component="span" sx={styles.followerCount}>
                       {profileContents.followingCount}
@@ -297,9 +282,9 @@ const Profile = () => {
               value={value}
               variant="fullWidth"
             >
-              <Tab sx={styles.tabs} value="one" label="Tweets" />
-              <Tab sx={styles.tabs} value="two" label="Replies" />
-              <Tab sx={styles.tabs} value="three" label="Likes" />
+              <Tab value="one" label="Tweets" />
+              <Tab value="two" label="Replies" />
+              <Tab value="three" label="Likes" />
             </Tabs>
             <Divider />
             {!loading && profileContents.userId && (

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -10,8 +10,6 @@ import { setUser } from "../state/slices/userSlice";
 const styles = {
   container: { height: "100%" },
   title: {
-    fontWeight: 700,
-    fontSize: 32,
     padding: 3,
     textAlign: "center",
   },

--- a/src/pages/Timeline.tsx
+++ b/src/pages/Timeline.tsx
@@ -6,9 +6,7 @@ import SideBar from "../components/SideBar/SideBar";
 
 const styles = {
   headerTitle: {
-    fontWeight: "bold",
-    paddingX: 2,
-    paddingY: 1,
+    padding: 2,
   },
 };
 
@@ -17,7 +15,9 @@ const Timeline = () => {
     <Layout
       middleContent={
         <Box>
-          <Typography sx={styles.headerTitle}>Timeline</Typography>
+          <Typography sx={styles.headerTitle} variant="h2">
+            Timeline
+          </Typography>
           <ComposePost placeholder="What's happening?" />
           <Divider />
           <PostList />

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -13,10 +13,6 @@ const styles = {
     width: 250,
     height: 250,
   },
-  title: {
-    fontWeight: 700,
-    fontSize: 32,
-  },
 };
 
 const Welcome = () => {
@@ -24,9 +20,7 @@ const Welcome = () => {
 
   return (
     <Box sx={styles.container}>
-      <Typography sx={styles.title} variant="h1">
-        Welcome to Chrip
-      </Typography>
+      <Typography variant="h1">Welcome to Chrip</Typography>
       <img style={styles.logo} src={"/logojade.png"} alt="Logo" />
       <Button
         size="large"

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -20,7 +20,7 @@ const Welcome = () => {
 
   return (
     <Box sx={styles.container}>
-      <Typography variant="h1">Welcome to Chrip</Typography>
+      <Typography variant="h1">Welcome to Chirp</Typography>
       <img style={styles.logo} src={"/logojade.png"} alt="Logo" />
       <Button
         size="large"

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -4,6 +4,7 @@ body,
   height: 100%;
   margin: 0;
   padding: 0;
+  font-family: "Inter", sans-serif;
 }
 
 html {

--- a/src/styles/Theme.tsx
+++ b/src/styles/Theme.tsx
@@ -61,8 +61,9 @@ const theme = createTheme({
       color: palette.black.main,
       fontSize: "0.9375rem",
       fontWeight: "bold",
+      lineHeight: 1.43,
     },
-    subtitle2: { color: palette.gray.dark, fontWeight: 400 },
+    subtitle2: { color: palette.gray.dark, fontWeight: 400, lineHeight: 1.43 },
   },
   components: {
     MuiButton: {

--- a/src/styles/Theme.tsx
+++ b/src/styles/Theme.tsx
@@ -5,47 +5,64 @@ declare module "@mui/material/styles/createPalette" {
   interface PaletteOptions {
     gray: PaletteOptions["primary"];
     white: PaletteOptions["primary"];
+    black: PaletteOptions["primary"];
   }
   interface Palette {
     gray: Palette["primary"];
     white: Palette["primary"];
+    black: Palette["primary"];
   }
 }
 
 const palette = createPalette({
   primary: {
-    main: "#22AA6F",
     contrastText: "#FFFFFF",
-    light: "#c6ebd4",
+    light: "#C6EBD4",
+    main: "#22AA6F",
   },
   secondary: {
     main: "#212529",
   },
   error: {
-    main: "#f44336",
+    main: "#F44336",
   },
   warning: {
-    main: "#ffa726",
+    main: "#FFA726",
   },
   success: {
     main: "#22AA6F",
   },
   gray: {
-    main: "#adb5bd",
+    dark: "#808080",
+    main: "#ADB5BD",
     light: "#F4F5F6",
   },
   white: {
-    main: "#ffffff",
+    main: "#FFFFFF",
+  },
+  black: {
+    main: "#000000",
   },
 });
 
 const theme = createTheme({
   palette: palette,
   typography: {
-    fontFamily: ["Inter"].join(","), // If we want to add more fonts, we can append to the array.
     button: {
       textTransform: "none",
     },
+    body1: { fontSize: "0.9375rem" },
+    body2: { color: palette.gray.dark, fontSize: "0.8125rem" },
+    fontFamily: ["Inter"].join(","), // If we want to add more fonts, we can append to the array.
+    h1: { fontSize: "1.75rem", fontWeight: 400 },
+    h2: { fontSize: "1.5rem", fontWeight: 500 },
+    h3: { fontSize: "1.25rem", fontWeight: 600 },
+    subtitle1: {
+      color: palette.black.main,
+      fontSize: "0.9375rem",
+      fontWeight: "bold",
+    },
+    subtitle2: { color: palette.gray.dark, fontWeight: 400 },
   },
   components: {
     MuiButton: {
@@ -91,6 +108,13 @@ const theme = createTheme({
       styleOverrides: {
         root: {
           borderRadius: "50px",
+        },
+      },
+    },
+    MuiTabs: {
+      styleOverrides: {
+        root: {
+          textTransform: "none",
         },
       },
     },

--- a/src/styles/Theme.tsx
+++ b/src/styles/Theme.tsx
@@ -44,7 +44,7 @@ const theme = createTheme({
   typography: {
     fontFamily: ["Inter"].join(","), // If we want to add more fonts, we can append to the array.
     button: {
-      fontSize: "1rem",
+      textTransform: "none",
     },
   },
   components: {

--- a/src/styles/Theme.tsx
+++ b/src/styles/Theme.tsx
@@ -3,18 +3,29 @@ import createPalette from "@mui/material/styles/createPalette";
 
 declare module "@mui/material/styles/createPalette" {
   interface PaletteOptions {
+    black: PaletteOptions["primary"];
     gray: PaletteOptions["primary"];
     white: PaletteOptions["primary"];
-    black: PaletteOptions["primary"];
   }
   interface Palette {
+    black: Palette["primary"];
     gray: Palette["primary"];
     white: Palette["primary"];
-    black: Palette["primary"];
   }
 }
 
 const palette = createPalette({
+  black: {
+    main: "#000000",
+  },
+  error: {
+    main: "#F44336",
+  },
+  gray: {
+    dark: "#808080",
+    main: "#ADB5BD",
+    light: "#F4F5F6",
+  },
   primary: {
     contrastText: "#FFFFFF",
     light: "#C6EBD4",
@@ -23,25 +34,14 @@ const palette = createPalette({
   secondary: {
     main: "#212529",
   },
-  error: {
-    main: "#F44336",
+  success: {
+    main: "#22AA6F",
   },
   warning: {
     main: "#FFA726",
   },
-  success: {
-    main: "#22AA6F",
-  },
-  gray: {
-    dark: "#808080",
-    main: "#ADB5BD",
-    light: "#F4F5F6",
-  },
   white: {
     main: "#FFFFFF",
-  },
-  black: {
-    main: "#000000",
   },
 });
 
@@ -67,13 +67,13 @@ const theme = createTheme({
   components: {
     MuiButton: {
       styleOverrides: {
-        root: {
-          borderRadius: "40px",
+        root: ({ theme }) => ({
+          borderRadius: theme.spacing(5),
           "&.Mui-disabled": {
             backgroundColor: palette.primary.light,
             color: palette.primary.contrastText,
           },
-        },
+        }),
       },
     },
     MuiButtonBase: {
@@ -94,6 +94,27 @@ const theme = createTheme({
         PaperProps: { sx: { borderRadius: 5 } },
       },
     },
+    MuiDialogActions: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          padding: theme.spacing(1, 2, 2, 2),
+        }),
+      },
+    },
+    MuiDialogContent: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          padding: theme.spacing(0),
+        }),
+      },
+    },
+    MuiDialogTitle: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          padding: theme.spacing(0.5),
+        }),
+      },
+    },
     MuiIconButton: {
       styleOverrides: {
         root: {
@@ -106,9 +127,9 @@ const theme = createTheme({
     },
     MuiOutlinedInput: {
       styleOverrides: {
-        root: {
-          borderRadius: "50px",
-        },
+        root: ({ theme }) => ({
+          borderRadius: theme.spacing(5),
+        }),
       },
     },
     MuiTabs: {
@@ -125,29 +146,8 @@ const theme = createTheme({
       styleOverrides: {
         root: {
           "&.MuiFormControl-root": {
-            padding: "0px",
+            padding: 0,
           },
-        },
-      },
-    },
-    MuiDialogTitle: {
-      styleOverrides: {
-        root: {
-          padding: "4px",
-        },
-      },
-    },
-    MuiDialogContent: {
-      styleOverrides: {
-        root: {
-          padding: "0px",
-        },
-      },
-    },
-    MuiDialogActions: {
-      styleOverrides: {
-        root: {
-          padding: "8px 16px 16px 16px",
         },
       },
     },


### PR DESCRIPTION
This PR seeks to standardize some of the typography in the app. It closes #91, closes #92, and fixes #96. There are a lot of changes in this PR, but I essentially took a look at what different types of text we were using around the app and mapped them to specific
 variants in `Theme.tsx`. This way, we can just use MUI's `Typography` component and simply specify the `variant` prop whenever we wanted text to look a certain way.

The following variants were made:

- h1 - rarely used but I made it for larger titles like the welcome page or the "select a message" prompt
- h2 - used for the titles at the top of each page (eg. "Timeline" or "Messages")
- h3 - is mainly used for the navbar items, but is also used in a few other places in the app
- subtitle1 - the display name text, which is bolded
- subtitle2 - the username text, which is gray and has a lighter font weight
- body1 - the standard text used throughout the app
- body2 - the exact same as subtitle2 (the username text), but in a smaller font size. It's used for smaller captions like the footer or to display timestamps in the messages

![image](https://github.com/Project-Chirp/chirp-frontend/assets/70828477/db2a7c44-57eb-4c4b-83d5-0484fc36ad38)