### PR TITLE
T102: Fix emoji picker overflow bug

### DIFF
--- a/src/components/Common/EmojiPickerIconButton.tsx
+++ b/src/components/Common/EmojiPickerIconButton.tsx
@@ -11,7 +11,7 @@ type EmojiPickerIconButtonProps = {
 };
 
 const styles = {
-  emojiContainer: { position: "absolute", zIndex: 1 },
+  emojiContainer: { position: "absolute", zIndex: 1, overflow: "visible" },
   emojiPicker: {
     "--epr-emoji-size": "25px",
   },

--- a/src/components/NavBar/PostButtonModal.tsx
+++ b/src/components/NavBar/PostButtonModal.tsx
@@ -39,7 +39,7 @@ export default function PostButtonModal({
       PaperProps={{ style: styles.paperProps }}
     >
       <DialogTitle>
-        <IconButton disableRipple onClick={onClose}>
+        <IconButton onClick={onClose}>
           <CloseIcon />
         </IconButton>
       </DialogTitle>

--- a/src/components/NavBar/PostButtonModal.tsx
+++ b/src/components/NavBar/PostButtonModal.tsx
@@ -3,13 +3,9 @@ import CloseIcon from "@mui/icons-material/Close";
 
 const styles = {
   dialog: {
-    maxHeight: "90%",
     ".MuiDialog-scrollPaper": { alignItems: "flex-start" },
   },
-  dialogContent: {
-    alignItems: "center",
-    justifyContent: "center",
-  },
+  dialogContent: { overflow: "visible" },
   dialogTitle: {
     paddingBottom: 0,
     paddingLeft: 0.5,

--- a/src/components/Posts/RepliesModal.tsx
+++ b/src/components/Posts/RepliesModal.tsx
@@ -1,8 +1,5 @@
 import {
   Box,
-  Card,
-  CardContent,
-  CardMedia,
   Dialog,
   DialogContent,
   DialogTitle,
@@ -32,14 +29,14 @@ const styles = {
   cardContent: {
     padding: 0,
     display: "flex",
+    overflow: "visible",
   },
   cardMedia: { maxWidth: 200, margin: "auto" },
   dialog: {
-    maxHeight: "90%",
+    ".MuiDialog-scrollPaper": { alignItems: "flex-start" },
   },
   dialogContent: {
-    alignItems: "center",
-    justifyContent: "center",
+    overflow: "visible",
   },
   line: {
     borderRightWidth: "3px",
@@ -71,7 +68,6 @@ const styles = {
   paperProps: {
     overflow: "visible",
     borderRadius: 20,
-    padding: 10, //Fix padding
   },
 };
 
@@ -97,8 +93,8 @@ export const RepliesModal = ({ onClose, open, post }: PostModalProps) => {
         </IconButton>
       </DialogTitle>
       <DialogContent sx={styles.dialogContent}>
-        <Card sx={styles.card}>
-          <CardContent sx={styles.cardContent}>
+        <Box sx={styles.card}>
+          <Box sx={styles.cardContent}>
             <Box sx={styles.avatarLineContainer}>
               <Box sx={styles.avatarBox}>
                 <UserAvatar username={post.username} />
@@ -129,20 +125,16 @@ export const RepliesModal = ({ onClose, open, post }: PostModalProps) => {
                 </Typography>
               </Typography>
             </Box>
-          </CardContent>
+          </Box>
           {post.imagePath && (
-            <CardMedia
-              sx={styles.cardMedia}
-              component="img"
-              image={post.imagePath}
-            />
+            <Box sx={styles.cardMedia} component="img" src={post.imagePath} />
           )}
           <ComposeReply
             placeholder="Post your reply"
             parentPostId={post.postId}
             onClose={onClose}
           />
-        </Card>
+        </Box>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/Posts/RepliesModal.tsx
+++ b/src/components/Posts/RepliesModal.tsx
@@ -25,18 +25,12 @@ const styles = {
     flexDirection: "column",
     gap: 0.25,
   },
-  card: { paddingX: 1 },
-  cardContent: {
-    padding: 0,
-    display: "flex",
-    overflow: "visible",
-  },
-  cardMedia: { maxWidth: 200, margin: "auto" },
   dialog: {
     ".MuiDialog-scrollPaper": { alignItems: "flex-start" },
   },
   dialogContent: {
     overflow: "visible",
+    paddingX: 1,
   },
   line: {
     borderRightWidth: "3px",
@@ -55,7 +49,17 @@ const styles = {
     justifyContent: "space-between",
     alignItems: "center",
   },
+  paperProps: {
+    overflow: "visible",
+    borderRadius: 20,
+  },
   postContent: {
+    padding: 0,
+    display: "flex",
+    overflow: "visible",
+  },
+  postMedia: { maxWidth: 200, margin: "auto" },
+  postText: {
     paddingRight: 3,
     paddingBottom: 0.5,
   },
@@ -65,10 +69,6 @@ const styles = {
     flexDirection: "column",
   },
   username: { fontSize: 14 },
-  paperProps: {
-    overflow: "visible",
-    borderRadius: 20,
-  },
 };
 
 type PostModalProps = {
@@ -88,53 +88,49 @@ export const RepliesModal = ({ onClose, open, post }: PostModalProps) => {
       PaperProps={{ style: styles.paperProps }}
     >
       <DialogTitle>
-        <IconButton disableRipple onClick={onClose}>
+        <IconButton onClick={onClose}>
           <CloseIcon />
         </IconButton>
       </DialogTitle>
       <DialogContent sx={styles.dialogContent}>
-        <Box sx={styles.card}>
-          <Box sx={styles.cardContent}>
-            <Box sx={styles.avatarLineContainer}>
-              <Box sx={styles.avatarBox}>
-                <UserAvatar username={post.username} />
-              </Box>
-              <Box sx={styles.lineBox}>
-                <Divider orientation="vertical" sx={styles.line} />
-              </Box>
+        <Box sx={styles.postContent}>
+          <Box sx={styles.avatarLineContainer}>
+            <Box sx={styles.avatarBox}>
+              <UserAvatar username={post.username} />
             </Box>
-            <Box sx={styles.textContent}>
-              <Box sx={styles.namesAndOption}>
-                <Typography variant="subtitle1">
-                  {post.displayName}
-                  <Typography component="span" variant="subtitle2">
-                    {` @${post.username}`}
-                  </Typography>
-                </Typography>
-                <IconButton size="small" sx={styles.moreButton}>
-                  <MoreVertIcon />
-                </IconButton>
-              </Box>
-              <Typography sx={styles.postContent}>
-                {post.textContent}
-              </Typography>
-              <Typography>
-                Replying to
-                <Typography component="span" color="primary">
+            <Box sx={styles.lineBox}>
+              <Divider orientation="vertical" sx={styles.line} />
+            </Box>
+          </Box>
+          <Box sx={styles.textContent}>
+            <Box sx={styles.namesAndOption}>
+              <Typography variant="subtitle1">
+                {post.displayName}
+                <Typography component="span" variant="subtitle2">
                   {` @${post.username}`}
                 </Typography>
               </Typography>
+              <IconButton size="small" sx={styles.moreButton}>
+                <MoreVertIcon />
+              </IconButton>
             </Box>
+            <Typography sx={styles.postText}>{post.textContent}</Typography>
+            <Typography>
+              Replying to
+              <Typography component="span" color="primary">
+                {` @${post.username}`}
+              </Typography>
+            </Typography>
           </Box>
-          {post.imagePath && (
-            <Box sx={styles.cardMedia} component="img" src={post.imagePath} />
-          )}
-          <ComposeReply
-            placeholder="Post your reply"
-            parentPostId={post.postId}
-            onClose={onClose}
-          />
         </Box>
+        {post.imagePath && (
+          <Box sx={styles.postMedia} component="img" src={post.imagePath} />
+        )}
+        <ComposeReply
+          placeholder="Post your reply"
+          parentPostId={post.postId}
+          onClose={onClose}
+        />
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
This resolves #102.

**Context**

There is a bug with the emoji picker when it's used in our modals, specifically `PostButtonModal` and `RepliesModal`. The bug makes the emoji picker overflow so that the entire modal isn't visible (ie. it has a scroll bar)

**Solution**

The solution is to change the overflow to visible in the dialog content div. Additional refactors were also made to get rid of an MUI `Card` component that was being used in the `RepliesModal` because the styling of the card when overflow was visible made the modal look different