### PR TITLE
T93, T112: Delete posts

### DIFF
--- a/src/components/Posts/ExpandedPostItem.tsx
+++ b/src/components/Posts/ExpandedPostItem.tsx
@@ -32,6 +32,7 @@ import { toggleLikePostRequest } from "../../utilities/postUtilities";
 import { Link as Routerlink } from "react-router-dom";
 import UserAvatar from "../Common/UserAvatar";
 import { useTheme } from "@mui/material/styles";
+import PostMenu from "./PostMenu";
 
 const styles = {
   actionButton: {
@@ -111,11 +112,7 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
       </Box>
       <CardHeader
         avatar={<UserAvatar username={post.username} />}
-        action={
-          <IconButton>
-            <MoreVertIcon />
-          </IconButton>
-        }
+        action={<PostMenu authorId={post.userId} postId={post.postId} />}
         title={
           <Link
             color={theme.typography.subtitle1.color}

--- a/src/components/Posts/ExpandedPostItem.tsx
+++ b/src/components/Posts/ExpandedPostItem.tsx
@@ -117,7 +117,9 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
       </Box>
       <CardHeader
         avatar={<UserAvatar username={post.username} />}
-        action={<PostMenu authorId={post.userId} postId={post.postId} />}
+        action={
+          <PostMenu authorId={post.userId} postId={post.postId} isExpanded />
+        }
         title={
           <Link
             color={theme.typography.subtitle1.color}

--- a/src/components/Posts/ExpandedPostItem.tsx
+++ b/src/components/Posts/ExpandedPostItem.tsx
@@ -2,23 +2,24 @@ import {
   Box,
   Button,
   Card,
+  CardActions,
   CardContent,
+  CardHeader,
+  CardMedia,
+  Divider,
+  IconButton,
+  Link,
   Stack,
   Typography,
-  Divider,
-  Link,
 } from "@mui/material";
-import KeyboardBackspaceIcon from "@mui/icons-material/KeyboardBackspace";
-import CardHeader from "@mui/material/CardHeader/CardHeader";
-import MoreVertIcon from "@mui/icons-material/MoreVert";
-import IconButton from "@mui/material/IconButton/IconButton";
-import CardMedia from "@mui/material/CardMedia/CardMedia";
-import CardActions from "@mui/material/CardActions/CardActions";
-import FavoriteBorderOutlinedIcon from "@mui/icons-material/FavoriteBorderOutlined";
-import FavoriteOutlinedIcon from "@mui/icons-material/FavoriteOutlined";
-import AddCommentOutlinedIcon from "@mui/icons-material/AddCommentOutlined";
-import RepeatOutlinedIcon from "@mui/icons-material/RepeatOutlined";
-import ShareOutlinedIcon from "@mui/icons-material/ShareOutlined";
+import {
+  AddCommentOutlined,
+  FavoriteBorderOutlined,
+  FavoriteOutlined,
+  KeyboardBackspace,
+  RepeatOutlined,
+  ShareOutlined,
+} from "@mui/icons-material";
 import axios from "axios";
 import { useAppDispatch, useAppSelector } from "../../state/hooks";
 import { useNavigate, useParams } from "react-router-dom";
@@ -88,16 +89,20 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
 
   useEffect(() => {
     const updatedExpandedPost = async () => {
-      const backupFetch = await axios.get(
-        "http://localhost:3001/api/posts/fetchPost",
-        {
-          params: {
-            userId: user.userId,
-            postId: urlParams.postId,
-          },
-        }
-      );
-      dispatch(setExpandedPost(backupFetch.data as Post));
+      try {
+        const backupFetch = await axios.get(
+          "http://localhost:3001/api/posts/fetchPost",
+          {
+            params: {
+              userId: user.userId,
+              postId: urlParams.postId,
+            },
+          }
+        );
+        dispatch(setExpandedPost(backupFetch.data as Post));
+      } catch (error) {
+        console.error("Failed to fetch post", error);
+      }
     };
     updatedExpandedPost();
   }, [dispatch, user.userId, urlParams.postId]);
@@ -106,7 +111,7 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
     <Card sx={styles.card}>
       <Box sx={styles.topHeader}>
         <IconButton onClick={() => navigate(-1)} sx={styles.backButton}>
-          <KeyboardBackspaceIcon color="secondary" />
+          <KeyboardBackspace color="secondary" />
         </IconButton>
         <Typography variant="h2">Post</Typography>
       </Box>
@@ -186,14 +191,14 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
           sx={styles.cardActions}
         >
           <IconButton>
-            <RepeatOutlinedIcon />
+            <RepeatOutlined />
           </IconButton>
           <IconButton
             onClick={() => {
               setOpen(true);
             }}
           >
-            <AddCommentOutlinedIcon />
+            <AddCommentOutlined />
           </IconButton>
           <IconButton
             onClick={() => {
@@ -207,13 +212,13 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
             sx={post.isLikedByCurrentUser ? styles.likedIcon : undefined}
           >
             {post.isLikedByCurrentUser ? (
-              <FavoriteOutlinedIcon />
+              <FavoriteOutlined />
             ) : (
-              <FavoriteBorderOutlinedIcon />
+              <FavoriteBorderOutlined />
             )}
           </IconButton>
           <IconButton>
-            <ShareOutlinedIcon />
+            <ShareOutlined />
           </IconButton>
         </Stack>
       </CardActions>

--- a/src/components/Posts/ExpandedPostItem.tsx
+++ b/src/components/Posts/ExpandedPostItem.tsx
@@ -83,6 +83,7 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
   const user = useAppSelector((state) => state.user);
   const urlParams = useParams();
   const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const updatedExpandedPost = async () => {
@@ -99,8 +100,6 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
     };
     updatedExpandedPost();
   }, [dispatch, user.userId, urlParams.postId]);
-
-  const navigate = useNavigate();
 
   return (
     <Card sx={styles.card}>

--- a/src/components/Posts/ExpandedPostItem.tsx
+++ b/src/components/Posts/ExpandedPostItem.tsx
@@ -118,7 +118,11 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
       <CardHeader
         avatar={<UserAvatar username={post.username} />}
         action={
-          <PostMenu authorId={post.userId} postId={post.postId} isExpanded />
+          <PostMenu
+            authorId={post.userId}
+            postId={post.postId}
+            isExpandedPost
+          />
         }
         title={
           <Link

--- a/src/components/Posts/PostDeleteConfirmationModal.tsx
+++ b/src/components/Posts/PostDeleteConfirmationModal.tsx
@@ -5,53 +5,38 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
-  Divider,
-  IconButton,
 } from "@mui/material";
 import { useAppDispatch, useAppSelector } from "../../state/hooks";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
 import { deletePost } from "../../state/slices/postsSlice";
-import CloseIcon from "@mui/icons-material/Close";
 
 const styles = {
   actions: {
-    justifyContent: "space-between",
-    paddingTop: 0,
+    display: "flex",
   },
   dialog: {
-    height: "auto",
     width: "20%",
     borderRadius: 5,
   },
   title: {
-    display: "flex",
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    flex: 1,
-    paddingX: 2,
-    paddingY: 1,
+    padding: 2,
+    textAlign: "center",
   },
   content: {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    justifyContent: "center",
     padding: 2,
-    gap: 1,
   },
   contentTextBold: { color: "black.main", textAlign: "center" },
   contextSubtext: { textAlign: "center" },
   deleteButton: {
-    width: "50%",
+    flex: 1,
     ":hover": {
       backgroundColor: "error.main",
       color: "white.main",
     },
   },
   cancelButton: {
-    width: "50%",
+    flex: 1,
     ":hover": {
       backgroundColor: "primary.main",
       color: "white.main",
@@ -84,6 +69,7 @@ const PostDeleteModal = ({
           userId: userId,
         },
       });
+
       if (isExpandedPost) {
         navigate(-1);
       } else {
@@ -97,13 +83,10 @@ const PostDeleteModal = ({
   };
   return (
     <Dialog onClose={onClose} open={open} PaperProps={{ sx: styles.dialog }}>
-      <DialogTitle sx={styles.title} variant="h6">
-        Delete Post?
+      <DialogTitle sx={styles.title} variant="subtitle1">
+        Are you sure you want to delete this post?
       </DialogTitle>
       <DialogContent sx={styles.content}>
-        <DialogContentText variant="subtitle1" sx={styles.contentTextBold}>
-          Are you sure you want to delete this post?
-        </DialogContentText>
         <DialogContentText sx={styles.contextSubtext}>
           This post will be lost forever as you will not be able to undo this
           action.

--- a/src/components/Posts/PostDeleteConfirmationModal.tsx
+++ b/src/components/Posts/PostDeleteConfirmationModal.tsx
@@ -12,9 +12,6 @@ import axios from "axios";
 import { deletePost } from "../../state/slices/postsSlice";
 
 const styles = {
-  actions: {
-    display: "flex",
-  },
   dialog: {
     width: "20%",
     borderRadius: 5,
@@ -25,9 +22,8 @@ const styles = {
   },
   content: {
     padding: 2,
+    textAlign: "center",
   },
-  contentTextBold: { color: "black.main", textAlign: "center" },
-  contextSubtext: { textAlign: "center" },
   deleteButton: {
     flex: 1,
     ":hover": {
@@ -69,7 +65,6 @@ const PostDeleteModal = ({
           userId: userId,
         },
       });
-
       if (isExpandedPost) {
         navigate(-1);
       } else {
@@ -81,18 +76,19 @@ const PostDeleteModal = ({
       onClose();
     }
   };
+
   return (
     <Dialog onClose={onClose} open={open} PaperProps={{ sx: styles.dialog }}>
       <DialogTitle sx={styles.title} variant="subtitle1">
         Are you sure you want to delete this post?
       </DialogTitle>
       <DialogContent sx={styles.content}>
-        <DialogContentText sx={styles.contextSubtext}>
+        <DialogContentText>
           This post will be lost forever as you will not be able to undo this
           action.
         </DialogContentText>
       </DialogContent>
-      <DialogActions sx={styles.actions}>
+      <DialogActions>
         <Button variant="outlined" onClick={onClose} sx={styles.cancelButton}>
           Cancel
         </Button>

--- a/src/components/Posts/PostDeleteModal.tsx
+++ b/src/components/Posts/PostDeleteModal.tsx
@@ -1,0 +1,78 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Typography,
+} from "@mui/material";
+import { useAppDispatch, useAppSelector } from "../../state/hooks";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
+import { deletePost } from "../../state/slices/postsSlice";
+
+const styles = {
+  dialog: {
+    height: "auto",
+    width: "35%",
+    borderRadius: 5,
+    padding: 1,
+  },
+  title: {
+    padding: 1,
+  },
+};
+
+type PostDeleteModalProps = {
+  onClose: () => void;
+  open: boolean;
+  postId: number;
+  isExpandedPost?: boolean;
+};
+
+const PostDeleteModal = ({
+  onClose,
+  open,
+  postId,
+  isExpandedPost,
+}: PostDeleteModalProps) => {
+  const userId = useAppSelector((state) => state.user.userId);
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  const handleDelete = async () => {
+    try {
+      await axios.delete(`http://localhost:3001/api/posts/deletePost`, {
+        data: {
+          postId: postId,
+          userId: userId,
+        },
+      });
+      if (isExpandedPost) {
+        navigate(-1);
+      } else {
+        dispatch(deletePost(postId));
+      }
+    } catch (error) {
+      console.error("Failed to delete the post", error);
+    } finally {
+      onClose();
+    }
+  };
+  return (
+    <Dialog onClose={onClose} open={open} PaperProps={{ sx: styles.dialog }}>
+      <DialogTitle sx={styles.title} variant="h6">
+        Are you sure you want to delete this post?
+      </DialogTitle>
+      <DialogActions>
+        <Button onClick={handleDelete} variant="outlined" color="error">
+          Delete
+        </Button>
+        <Button variant="outlined">Cancel</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default PostDeleteModal;

--- a/src/components/Posts/PostDeleteModal.tsx
+++ b/src/components/Posts/PostDeleteModal.tsx
@@ -1,12 +1,4 @@
-import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-  Typography,
-} from "@mui/material";
+import { Button, Dialog, DialogActions, DialogTitle } from "@mui/material";
 import { useAppDispatch, useAppSelector } from "../../state/hooks";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
@@ -69,7 +61,9 @@ const PostDeleteModal = ({
         <Button onClick={handleDelete} variant="outlined" color="error">
           Delete
         </Button>
-        <Button variant="outlined">Cancel</Button>
+        <Button variant="outlined" onClick={onClose}>
+          Cancel
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/src/components/Posts/PostDeleteModal.tsx
+++ b/src/components/Posts/PostDeleteModal.tsx
@@ -42,6 +42,7 @@ const styles = {
     gap: 1,
   },
   contentTextBold: { color: "black.main", textAlign: "center" },
+  contextSubtext: { textAlign: "center" },
   deleteButton: {
     width: "50%",
     ":hover": {
@@ -98,16 +99,15 @@ const PostDeleteModal = ({
     <Dialog onClose={onClose} open={open} PaperProps={{ sx: styles.dialog }}>
       <DialogTitle sx={styles.title} variant="h6">
         Delete Post?
-        <IconButton onClick={onClose}>
-          <CloseIcon />
-        </IconButton>
       </DialogTitle>
-      <Divider />
       <DialogContent sx={styles.content}>
         <DialogContentText variant="subtitle1" sx={styles.contentTextBold}>
           Are you sure you want to delete this post?
         </DialogContentText>
-        <DialogContentText>You cannot undo this action.</DialogContentText>
+        <DialogContentText sx={styles.contextSubtext}>
+          This post will be lost forever as you will not be able to undo this
+          action.
+        </DialogContentText>
       </DialogContent>
       <DialogActions sx={styles.actions}>
         <Button variant="outlined" onClick={onClose} sx={styles.cancelButton}>

--- a/src/components/Posts/PostDeleteModal.tsx
+++ b/src/components/Posts/PostDeleteModal.tsx
@@ -1,18 +1,60 @@
-import { Button, Dialog, DialogActions, DialogTitle } from "@mui/material";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Divider,
+  IconButton,
+} from "@mui/material";
 import { useAppDispatch, useAppSelector } from "../../state/hooks";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
 import { deletePost } from "../../state/slices/postsSlice";
+import CloseIcon from "@mui/icons-material/Close";
 
 const styles = {
+  actions: {
+    justifyContent: "space-between",
+    paddingTop: 0,
+  },
   dialog: {
     height: "auto",
-    width: "35%",
+    width: "20%",
     borderRadius: 5,
-    padding: 1,
   },
   title: {
-    padding: 1,
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    flex: 1,
+    paddingX: 2,
+    paddingY: 1,
+  },
+  content: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 2,
+    gap: 1,
+  },
+  contentTextBold: { color: "black.main", textAlign: "center" },
+  deleteButton: {
+    width: "50%",
+    ":hover": {
+      backgroundColor: "error.main",
+      color: "white.main",
+    },
+  },
+  cancelButton: {
+    width: "50%",
+    ":hover": {
+      backgroundColor: "primary.main",
+      color: "white.main",
+    },
   },
 };
 
@@ -55,14 +97,29 @@ const PostDeleteModal = ({
   return (
     <Dialog onClose={onClose} open={open} PaperProps={{ sx: styles.dialog }}>
       <DialogTitle sx={styles.title} variant="h6">
-        Are you sure you want to delete this post?
+        Delete Post?
+        <IconButton onClick={onClose}>
+          <CloseIcon />
+        </IconButton>
       </DialogTitle>
-      <DialogActions>
-        <Button onClick={handleDelete} variant="outlined" color="error">
-          Delete
-        </Button>
-        <Button variant="outlined" onClick={onClose}>
+      <Divider />
+      <DialogContent sx={styles.content}>
+        <DialogContentText variant="subtitle1" sx={styles.contentTextBold}>
+          Are you sure you want to delete this post?
+        </DialogContentText>
+        <DialogContentText>You cannot undo this action.</DialogContentText>
+      </DialogContent>
+      <DialogActions sx={styles.actions}>
+        <Button variant="outlined" onClick={onClose} sx={styles.cancelButton}>
           Cancel
+        </Button>
+        <Button
+          onClick={handleDelete}
+          variant="outlined"
+          color="error"
+          sx={styles.deleteButton}
+        >
+          Delete
         </Button>
       </DialogActions>
     </Dialog>

--- a/src/components/Posts/PostItem.tsx
+++ b/src/components/Posts/PostItem.tsx
@@ -56,15 +56,6 @@ const styles = {
   displayName: {
     paddingRight: 0.5,
   },
-  menu: {
-    borderRadius: 4,
-  },
-  menuItem: {
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "space-between",
-    width: "100%",
-  },
 };
 
 const PostItem = ({ post }: PostProps) => {

--- a/src/components/Posts/PostItem.tsx
+++ b/src/components/Posts/PostItem.tsx
@@ -38,6 +38,7 @@ import formatTimestamp from "../../utilities/formatTimestamp";
 import { Link as Routerlink } from "react-router-dom";
 import UserAvatar from "../Common/UserAvatar";
 import axios from "axios";
+import PostMenu from "./PostMenu";
 
 type PostProps = {
   post: Post;
@@ -80,85 +81,19 @@ const PostItem = ({ post }: PostProps) => {
   const dispatch = useAppDispatch();
   const user = useAppSelector((state) => state.user);
   const [open, setOpen] = useState(false);
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-  const [menuOpen, setMenuOpen] = useState(false);
-
   const navigate = useNavigate();
+
   const routeChange = () => {
     const path = `/post/${post.postId}`;
     navigate(path);
     dispatch(setExpandedPost(post));
   };
 
-  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-    setMenuOpen(true);
-  };
-
-  const handleMenuClose = () => {
-    setAnchorEl(null);
-    setMenuOpen(false);
-  };
-
-  const handleDelete = async () => {
-    try {
-      const result = await axios.delete(
-        `http://localhost:3001/api/posts/deletePost`,
-        {
-          data: {
-            postId: post.postId,
-          },
-        }
-      );
-      dispatch(deletePost(post.postId));
-      return result.data;
-    } catch (error) {
-      console.error("Failed to delete the post", error);
-    } finally {
-      handleMenuClose();
-    }
-  };
-
-  const handleTemporary = () => {
-    handleMenuClose();
-  };
-
   return (
     <Card sx={styles.card}>
       <CardHeader
         avatar={<UserAvatar username={post.username} />}
-        action={
-          <>
-            <IconButton onClick={handleMenuOpen}>
-              <MoreVertIcon />
-            </IconButton>
-            <Menu
-              anchorEl={anchorEl}
-              open={menuOpen}
-              onClose={handleMenuClose}
-              PaperProps={{
-                sx: styles.menu,
-              }}
-            >
-              {user.userId === post.userId && (
-                <>
-                  <MenuItem sx={styles.menuItem} onClick={handleTemporary}>
-                    <EditIcon />
-                    <Typography>Edit Post</Typography>
-                  </MenuItem>
-                  <MenuItem onClick={handleDelete} sx={styles.menuItem}>
-                    <DeleteIcon color="error" />
-                    <Typography color="error">Delete Post</Typography>
-                  </MenuItem>
-                </>
-              )}
-              <MenuItem sx={styles.menuItem} onClick={handleTemporary}>
-                <LinkIcon />
-                <Typography>Copy Link</Typography>
-              </MenuItem>
-            </Menu>
-          </>
-        }
+        action={<PostMenu authorId={post.userId} postId={post.postId} />}
         title={
           <Box>
             <Link

--- a/src/components/Posts/PostItem.tsx
+++ b/src/components/Posts/PostItem.tsx
@@ -3,32 +3,24 @@ import {
   Button,
   Card,
   CardActionArea,
+  CardActions,
   CardContent,
+  CardHeader,
+  CardMedia,
+  IconButton,
   Link,
-  Menu,
-  MenuItem,
   Typography,
   useTheme,
 } from "@mui/material";
-import CardHeader from "@mui/material/CardHeader/CardHeader";
-import MoreVertIcon from "@mui/icons-material/MoreVert";
-import IconButton from "@mui/material/IconButton/IconButton";
-import CardMedia from "@mui/material/CardMedia/CardMedia";
-import CardActions from "@mui/material/CardActions/CardActions";
-import FavoriteBorderOutlinedIcon from "@mui/icons-material/FavoriteBorderOutlined";
-import FavoriteOutlinedIcon from "@mui/icons-material/FavoriteOutlined";
-import AddCommentOutlinedIcon from "@mui/icons-material/AddCommentOutlined";
-import RepeatOutlinedIcon from "@mui/icons-material/RepeatOutlined";
-import ShareOutlinedIcon from "@mui/icons-material/ShareOutlined";
-import EditIcon from "@mui/icons-material/Edit";
-import DeleteIcon from "@mui/icons-material/Delete";
-import LinkIcon from "@mui/icons-material/Link";
-import { useAppDispatch, useAppSelector } from "../../state/hooks";
 import {
-  Post,
-  deletePost,
-  toggleLikePost,
-} from "../../state/slices/postsSlice";
+  AddCommentOutlined,
+  FavoriteBorderOutlined,
+  FavoriteOutlined,
+  RepeatOutlined,
+  ShareOutlined,
+} from "@mui/icons-material";
+import { useAppDispatch, useAppSelector } from "../../state/hooks";
+import { Post, toggleLikePost } from "../../state/slices/postsSlice";
 import { useNavigate } from "react-router-dom";
 import { setExpandedPost } from "../../state/slices/postsSlice";
 import { useState } from "react";
@@ -37,7 +29,6 @@ import { toggleLikePostRequest } from "../../utilities/postUtilities";
 import formatTimestamp from "../../utilities/formatTimestamp";
 import { Link as Routerlink } from "react-router-dom";
 import UserAvatar from "../Common/UserAvatar";
-import axios from "axios";
 import PostMenu from "./PostMenu";
 
 type PostProps = {
@@ -134,14 +125,14 @@ const PostItem = ({ post }: PostProps) => {
       </CardActionArea>
       <CardActions>
         <Box sx={styles.cardActions}>
-          <Button startIcon={<RepeatOutlinedIcon />} sx={styles.defaultButton}>
+          <Button startIcon={<RepeatOutlined />} sx={styles.defaultButton}>
             {post.numberOfReposts}
           </Button>
           <Button
             onClick={() => {
               setOpen(true);
             }}
-            startIcon={<AddCommentOutlinedIcon />}
+            startIcon={<AddCommentOutlined />}
             sx={styles.defaultButton}
           >
             {post.numberOfReplies}
@@ -157,9 +148,9 @@ const PostItem = ({ post }: PostProps) => {
             }}
             startIcon={
               post.isLikedByCurrentUser ? (
-                <FavoriteOutlinedIcon />
+                <FavoriteOutlined />
               ) : (
-                <FavoriteBorderOutlinedIcon />
+                <FavoriteBorderOutlined />
               )
             }
             sx={
@@ -171,7 +162,7 @@ const PostItem = ({ post }: PostProps) => {
             {post.numberOfLikes}
           </Button>
           <IconButton>
-            <ShareOutlinedIcon />
+            <ShareOutlined />
           </IconButton>
         </Box>
       </CardActions>

--- a/src/components/Posts/PostItem.tsx
+++ b/src/components/Posts/PostItem.tsx
@@ -102,22 +102,25 @@ const PostItem = ({ post }: PostProps) => {
 
   const handleDelete = async () => {
     try {
-      const result = axios.delete(
+      const result = await axios.delete(
         `http://localhost:3001/api/posts/deletePost`,
         {
           data: {
-            userId: post.userId,
             postId: post.postId,
           },
         }
       );
-
       dispatch(deletePost(post.postId));
+      return result.data;
     } catch (error) {
       console.error("Failed to delete the post", error);
     } finally {
       handleMenuClose();
     }
+  };
+
+  const handleTemporary = () => {
+    handleMenuClose();
   };
 
   return (
@@ -137,17 +140,21 @@ const PostItem = ({ post }: PostProps) => {
                 sx: styles.menu,
               }}
             >
-              <MenuItem sx={styles.menuItem}>
-                <EditIcon />
-                <Typography>Edit Post</Typography>
-              </MenuItem>
-              <MenuItem onClick={handleDelete} sx={styles.menuItem}>
-                <DeleteIcon color="error" />
-                <Typography color="error">Delete Post</Typography>
-              </MenuItem>
-              <MenuItem sx={styles.menuItem}>
+              {user.userId === post.userId && (
+                <>
+                  <MenuItem sx={styles.menuItem} onClick={handleTemporary}>
+                    <EditIcon />
+                    <Typography>Edit Post</Typography>
+                  </MenuItem>
+                  <MenuItem onClick={handleDelete} sx={styles.menuItem}>
+                    <DeleteIcon color="error" />
+                    <Typography color="error">Delete Post</Typography>
+                  </MenuItem>
+                </>
+              )}
+              <MenuItem sx={styles.menuItem} onClick={handleTemporary}>
                 <LinkIcon />
-                <Typography>Copy List</Typography>
+                <Typography>Copy Link</Typography>
               </MenuItem>
             </Menu>
           </>

--- a/src/components/Posts/PostMenu.tsx
+++ b/src/components/Posts/PostMenu.tsx
@@ -11,6 +11,7 @@ import { MoreVert, Edit, Delete, Link } from "@mui/icons-material";
 import axios from "axios";
 import { deletePost } from "../../state/slices/postsSlice";
 import { useNavigate } from "react-router-dom";
+import PostDeleteModal from "./PostDeleteModal";
 
 type PostMenuProps = {
   authorId: number;
@@ -39,38 +40,33 @@ const PostMenu = ({
 }: PostMenuProps) => {
   const userId = useAppSelector((state) => state.user.userId);
   const menuRef = useRef<HTMLButtonElement>(null);
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [deleteModal, setDeleteModal] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
 
   const handleDelete = async () => {
+    setDeleteModal(true);
     try {
-      const result = await axios.delete(
-        `http://localhost:3001/api/posts/deletePost`,
-        {
-          data: {
-            postId: postId,
-            userId: userId,
-          },
-        }
-      );
-
-      if (isExpandedPost) {
-        dispatch(deletePost(postId));
-      } else {
-        navigate(-1);
-      }
+      // const result = await axios.delete(
+      //   `http://localhost:3001/api/posts/deletePost`,
+      //   {
+      //     data: {
+      //       postId: postId,
+      //       userId: userId,
+      //     },
+      //   }
+      // );
+      // if (isExpandedPost) {
+      //   dispatch(deletePost(postId));
+      // } else {
+      //   navigate(-1);
+      // }
     } catch (error) {
       console.error("Failed to delete the post", error);
     } finally {
-      handleMenuClose();
+      setMenuOpen(false);
     }
-  };
-
-  const handleMenuClose = () => {
-    setAnchorEl(null);
-    setMenuOpen(false);
   };
 
   return (
@@ -81,14 +77,14 @@ const PostMenu = ({
       <Menu
         anchorEl={menuRef.current}
         open={menuOpen}
-        onClose={handleMenuClose}
+        onClose={() => setMenuOpen(false)}
         PaperProps={{
           sx: styles.menu,
         }}
         MenuListProps={{ sx: { padding: 0 } }}
       >
         {userId === authorId && (
-          <MenuItem sx={styles.menuItem} onClick={handleMenuClose}>
+          <MenuItem sx={styles.menuItem} onClick={() => setMenuOpen(false)}>
             <ListItemIcon>
               <Edit sx={styles.icon} />
             </ListItemIcon>
@@ -112,7 +108,7 @@ const PostMenu = ({
             </ListItemText>
           </MenuItem>
         )}
-        <MenuItem sx={styles.menuItem} onClick={handleMenuClose}>
+        <MenuItem sx={styles.menuItem} onClick={() => setMenuOpen(false)}>
           <ListItemIcon>
             <Link sx={styles.icon} />
           </ListItemIcon>
@@ -121,6 +117,12 @@ const PostMenu = ({
           </ListItemText>
         </MenuItem>
       </Menu>
+      <PostDeleteModal
+        onClose={() => setDeleteModal(false)}
+        open={deleteModal}
+        postId={postId}
+        isExpandedPost={isExpandedPost}
+      />
     </>
   );
 };

--- a/src/components/Posts/PostMenu.tsx
+++ b/src/components/Posts/PostMenu.tsx
@@ -42,32 +42,6 @@ const PostMenu = ({
   const menuRef = useRef<HTMLButtonElement>(null);
   const [deleteModal, setDeleteModal] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
-  const dispatch = useAppDispatch();
-  const navigate = useNavigate();
-
-  const handleDelete = async () => {
-    setDeleteModal(true);
-    try {
-      // const result = await axios.delete(
-      //   `http://localhost:3001/api/posts/deletePost`,
-      //   {
-      //     data: {
-      //       postId: postId,
-      //       userId: userId,
-      //     },
-      //   }
-      // );
-      // if (isExpandedPost) {
-      //   dispatch(deletePost(postId));
-      // } else {
-      //   navigate(-1);
-      // }
-    } catch (error) {
-      console.error("Failed to delete the post", error);
-    } finally {
-      setMenuOpen(false);
-    }
-  };
 
   return (
     <>
@@ -94,7 +68,7 @@ const PostMenu = ({
           </MenuItem>
         )}
         {userId === authorId && (
-          <MenuItem sx={styles.menuItem} onClick={handleDelete}>
+          <MenuItem sx={styles.menuItem} onClick={() => setDeleteModal(true)}>
             <ListItemIcon>
               <Delete color="error" />
             </ListItemIcon>

--- a/src/components/Posts/PostMenu.tsx
+++ b/src/components/Posts/PostMenu.tsx
@@ -48,6 +48,7 @@ const PostMenu = ({ authorId, postId }: PostMenuProps) => {
         {
           data: {
             postId: postId,
+            userId: userId,
           },
         }
       );
@@ -77,19 +78,21 @@ const PostMenu = ({ authorId, postId }: PostMenuProps) => {
           sx: styles.menu,
         }}
       >
-        {userId === authorId && (
-          <>
-            <MenuItem sx={styles.menuItem} onClick={handleTemporary}>
-              <EditIcon />
-              <Typography>Edit Post</Typography>
-            </MenuItem>
-            <MenuItem onClick={handleDelete} sx={styles.menuItem}>
-              <DeleteIcon color="error" />
-              <Typography color="error">Delete Post</Typography>
-            </MenuItem>
-          </>
-        )}
-        <MenuItem sx={styles.menuItem} onClick={handleTemporary}>
+        {userId === authorId && [
+          <MenuItem sx={styles.menuItem} onClick={handleTemporary} key="edit">
+            <EditIcon />
+            <Typography>Edit Post</Typography>
+          </MenuItem>,
+          <MenuItem onClick={handleDelete} sx={styles.menuItem} key="delete">
+            <DeleteIcon color="error" />
+            <Typography color="error">Delete Post</Typography>
+          </MenuItem>,
+        ]}
+        <MenuItem
+          sx={styles.menuItem}
+          onClick={handleTemporary}
+          key="copy-link"
+        >
           <LinkIcon />
           <Typography>Copy Link</Typography>
         </MenuItem>

--- a/src/components/Posts/PostMenu.tsx
+++ b/src/components/Posts/PostMenu.tsx
@@ -5,13 +5,10 @@ import {
   Menu,
   MenuItem,
 } from "@mui/material";
-import React, { useRef, useState } from "react";
-import { useAppDispatch, useAppSelector } from "../../state/hooks";
+import { useRef, useState } from "react";
+import { useAppSelector } from "../../state/hooks";
 import { MoreVert, Edit, Delete, Link } from "@mui/icons-material";
-import axios from "axios";
-import { deletePost } from "../../state/slices/postsSlice";
-import { useNavigate } from "react-router-dom";
-import PostDeleteModal from "./PostDeleteModal";
+import PostDeleteConfirmationModal from "./PostDeleteConfirmationModal";
 
 type PostMenuProps = {
   authorId: number;
@@ -23,7 +20,6 @@ const styles = {
   icon: {
     color: "black.main",
   },
-  listItemText: { fontWeight: "bold" },
   menu: {
     borderRadius: 4,
   },
@@ -31,6 +27,7 @@ const styles = {
     paddingX: 1.5,
     paddingY: 1,
   },
+  menuList: { padding: 0 },
 };
 
 const PostMenu = ({
@@ -40,7 +37,8 @@ const PostMenu = ({
 }: PostMenuProps) => {
   const userId = useAppSelector((state) => state.user.userId);
   const menuRef = useRef<HTMLButtonElement>(null);
-  const [deleteModal, setDeleteModal] = useState(false);
+  const [deleteConfirmationModalOpen, setDeleteConfirmationModalOpen] =
+    useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
 
   return (
@@ -55,7 +53,7 @@ const PostMenu = ({
         PaperProps={{
           sx: styles.menu,
         }}
-        MenuListProps={{ sx: { padding: 0 } }}
+        MenuListProps={{ sx: styles.menuList }}
       >
         {userId === authorId && (
           <MenuItem sx={styles.menuItem} onClick={() => setMenuOpen(false)}>
@@ -72,7 +70,7 @@ const PostMenu = ({
             sx={styles.menuItem}
             onClick={() => {
               setMenuOpen(false);
-              setDeleteModal(true);
+              setDeleteConfirmationModalOpen(true);
             }}
           >
             <ListItemIcon>
@@ -97,9 +95,9 @@ const PostMenu = ({
           </ListItemText>
         </MenuItem>
       </Menu>
-      <PostDeleteModal
-        onClose={() => setDeleteModal(false)}
-        open={deleteModal}
+      <PostDeleteConfirmationModal
+        onClose={() => setDeleteConfirmationModalOpen(false)}
+        open={deleteConfirmationModalOpen}
         postId={postId}
         isExpandedPost={isExpandedPost}
       />

--- a/src/components/Posts/PostMenu.tsx
+++ b/src/components/Posts/PostMenu.tsx
@@ -17,6 +17,10 @@ type PostMenuProps = {
 };
 
 const styles = {
+  listItemIcon: {
+    "&.MuiListItemIcon-root": { color: "black.main" },
+  },
+  listItemText: { fontWeight: "bold" },
   menu: {
     borderRadius: 4,
   },
@@ -77,25 +81,34 @@ const PostMenu = ({ authorId, postId }: PostMenuProps) => {
       >
         {userId === authorId && [
           <MenuItem onClick={handleTemporary} key="edit">
-            <ListItemIcon>
+            <ListItemIcon sx={styles.listItemIcon}>
               <Edit />
             </ListItemIcon>
-            <ListItemText>Edit Post</ListItemText>
+            <ListItemText primaryTypographyProps={styles.listItemText}>
+              Edit Post
+            </ListItemText>
           </MenuItem>,
           <MenuItem onClick={handleDelete} key="delete">
             <ListItemIcon>
               <Delete color="error" />
             </ListItemIcon>
-            <ListItemText primaryTypographyProps={{ color: "error" }}>
+            <ListItemText
+              primaryTypographyProps={{
+                ...styles.listItemText,
+                color: "error",
+              }}
+            >
               Delete Post
             </ListItemText>
           </MenuItem>,
         ]}
         <MenuItem onClick={handleTemporary} key="copy-link">
-          <ListItemIcon>
+          <ListItemIcon sx={styles.listItemIcon}>
             <Link />
           </ListItemIcon>
-          <ListItemText>Copy Link</ListItemText>
+          <ListItemText primaryTypographyProps={styles.listItemText}>
+            Copy Link
+          </ListItemText>
         </MenuItem>
       </Menu>
     </>

--- a/src/components/Posts/PostMenu.tsx
+++ b/src/components/Posts/PostMenu.tsx
@@ -68,7 +68,13 @@ const PostMenu = ({
           </MenuItem>
         )}
         {userId === authorId && (
-          <MenuItem sx={styles.menuItem} onClick={() => setDeleteModal(true)}>
+          <MenuItem
+            sx={styles.menuItem}
+            onClick={() => {
+              setMenuOpen(false);
+              setDeleteModal(true);
+            }}
+          >
             <ListItemIcon>
               <Delete color="error" />
             </ListItemIcon>

--- a/src/components/Posts/PostMenu.tsx
+++ b/src/components/Posts/PostMenu.tsx
@@ -5,7 +5,7 @@ import {
   Menu,
   MenuItem,
 } from "@mui/material";
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { useAppDispatch, useAppSelector } from "../../state/hooks";
 import { MoreVert, Edit, Delete, Link } from "@mui/icons-material";
 import axios from "axios";
@@ -15,21 +15,30 @@ import { useNavigate } from "react-router-dom";
 type PostMenuProps = {
   authorId: number;
   postId: number;
-  isExpanded?: boolean;
+  isExpandedPost?: boolean;
 };
 
 const styles = {
-  listItemIcon: {
-    "&.MuiListItemIcon-root": { color: "black.main" },
+  icon: {
+    color: "black.main",
   },
   listItemText: { fontWeight: "bold" },
   menu: {
     borderRadius: 4,
   },
+  menuItem: {
+    paddingX: 1.5,
+    paddingY: 1,
+  },
 };
 
-const PostMenu = ({ authorId, postId, isExpanded = false }: PostMenuProps) => {
+const PostMenu = ({
+  authorId,
+  postId,
+  isExpandedPost = false,
+}: PostMenuProps) => {
   const userId = useAppSelector((state) => state.user.userId);
+  const menuRef = useRef<HTMLButtonElement>(null);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const dispatch = useAppDispatch();
@@ -47,8 +56,11 @@ const PostMenu = ({ authorId, postId, isExpanded = false }: PostMenuProps) => {
         }
       );
 
-      isExpanded ? handleExpandedPostDelete() : handlePostDelete();
-      return result.data;
+      if (isExpandedPost) {
+        dispatch(deletePost(postId));
+      } else {
+        navigate(-1);
+      }
     } catch (error) {
       console.error("Failed to delete the post", error);
     } finally {
@@ -56,69 +68,55 @@ const PostMenu = ({ authorId, postId, isExpanded = false }: PostMenuProps) => {
     }
   };
 
-  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-    setMenuOpen(true);
-  };
-
   const handleMenuClose = () => {
     setAnchorEl(null);
     setMenuOpen(false);
   };
 
-  const handlePostDelete = () => {
-    dispatch(deletePost(postId));
-  };
-
-  const handleExpandedPostDelete = () => {
-    navigate(-1);
-  };
-
-  const handleTemporary = () => {
-    handleMenuClose();
-  };
-
   return (
     <>
-      <IconButton onClick={handleMenuOpen}>
+      <IconButton ref={menuRef} onClick={() => setMenuOpen(true)}>
         <MoreVert />
       </IconButton>
       <Menu
-        anchorEl={anchorEl}
+        anchorEl={menuRef.current}
         open={menuOpen}
         onClose={handleMenuClose}
         PaperProps={{
           sx: styles.menu,
         }}
+        MenuListProps={{ sx: { padding: 0 } }}
       >
-        {userId === authorId && [
-          <MenuItem onClick={handleTemporary} key="edit">
-            <ListItemIcon sx={styles.listItemIcon}>
-              <Edit />
+        {userId === authorId && (
+          <MenuItem sx={styles.menuItem} onClick={handleMenuClose}>
+            <ListItemIcon>
+              <Edit sx={styles.icon} />
             </ListItemIcon>
-            <ListItemText primaryTypographyProps={styles.listItemText}>
+            <ListItemText primaryTypographyProps={{ variant: "subtitle1" }}>
               Edit Post
             </ListItemText>
-          </MenuItem>,
-          <MenuItem onClick={handleDelete} key="delete">
+          </MenuItem>
+        )}
+        {userId === authorId && (
+          <MenuItem sx={styles.menuItem} onClick={handleDelete}>
             <ListItemIcon>
               <Delete color="error" />
             </ListItemIcon>
             <ListItemText
               primaryTypographyProps={{
-                ...styles.listItemText,
+                variant: "subtitle1",
                 color: "error",
               }}
             >
               Delete Post
             </ListItemText>
-          </MenuItem>,
-        ]}
-        <MenuItem onClick={handleTemporary} key="copy-link">
-          <ListItemIcon sx={styles.listItemIcon}>
-            <Link />
+          </MenuItem>
+        )}
+        <MenuItem sx={styles.menuItem} onClick={handleMenuClose}>
+          <ListItemIcon>
+            <Link sx={styles.icon} />
           </ListItemIcon>
-          <ListItemText primaryTypographyProps={styles.listItemText}>
+          <ListItemText primaryTypographyProps={{ variant: "subtitle1" }}>
             Copy Link
           </ListItemText>
         </MenuItem>

--- a/src/components/Posts/PostMenu.tsx
+++ b/src/components/Posts/PostMenu.tsx
@@ -20,12 +20,6 @@ const styles = {
   menu: {
     borderRadius: 4,
   },
-  menuItem: {
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "space-between",
-    width: "100%",
-  },
 };
 
 const PostMenu = ({ authorId, postId }: PostMenuProps) => {
@@ -82,13 +76,13 @@ const PostMenu = ({ authorId, postId }: PostMenuProps) => {
         }}
       >
         {userId === authorId && [
-          <MenuItem sx={styles.menuItem} onClick={handleTemporary} key="edit">
+          <MenuItem onClick={handleTemporary} key="edit">
             <ListItemIcon>
               <Edit />
             </ListItemIcon>
             <ListItemText>Edit Post</ListItemText>
           </MenuItem>,
-          <MenuItem onClick={handleDelete} sx={styles.menuItem} key="delete">
+          <MenuItem onClick={handleDelete} key="delete">
             <ListItemIcon>
               <Delete color="error" />
             </ListItemIcon>
@@ -97,11 +91,7 @@ const PostMenu = ({ authorId, postId }: PostMenuProps) => {
             </ListItemText>
           </MenuItem>,
         ]}
-        <MenuItem
-          sx={styles.menuItem}
-          onClick={handleTemporary}
-          key="copy-link"
-        >
+        <MenuItem onClick={handleTemporary} key="copy-link">
           <ListItemIcon>
             <Link />
           </ListItemIcon>

--- a/src/components/Posts/PostMenu.tsx
+++ b/src/components/Posts/PostMenu.tsx
@@ -1,0 +1,101 @@
+import { IconButton, Menu, MenuItem, Typography } from "@mui/material";
+import React, { useState } from "react";
+import { useAppDispatch, useAppSelector } from "../../state/hooks";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
+import LinkIcon from "@mui/icons-material/Link";
+import axios from "axios";
+import { deletePost } from "../../state/slices/postsSlice";
+
+type PostMenuProps = {
+  authorId: number;
+  postId: number;
+};
+
+const styles = {
+  menu: {
+    borderRadius: 4,
+  },
+  menuItem: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    width: "100%",
+  },
+};
+
+const PostMenu = ({ authorId, postId }: PostMenuProps) => {
+  const userId = useAppSelector((state) => state.user.userId);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const dispatch = useAppDispatch();
+
+  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+    setMenuOpen(true);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+    setMenuOpen(false);
+  };
+
+  const handleDelete = async () => {
+    try {
+      const result = await axios.delete(
+        `http://localhost:3001/api/posts/deletePost`,
+        {
+          data: {
+            postId: postId,
+          },
+        }
+      );
+      dispatch(deletePost(postId));
+      return result.data;
+    } catch (error) {
+      console.error("Failed to delete the post", error);
+    } finally {
+      handleMenuClose();
+    }
+  };
+
+  const handleTemporary = () => {
+    handleMenuClose();
+  };
+
+  return (
+    <>
+      <IconButton onClick={handleMenuOpen}>
+        <MoreVertIcon />
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={menuOpen}
+        onClose={handleMenuClose}
+        PaperProps={{
+          sx: styles.menu,
+        }}
+      >
+        {userId === authorId && (
+          <>
+            <MenuItem sx={styles.menuItem} onClick={handleTemporary}>
+              <EditIcon />
+              <Typography>Edit Post</Typography>
+            </MenuItem>
+            <MenuItem onClick={handleDelete} sx={styles.menuItem}>
+              <DeleteIcon color="error" />
+              <Typography color="error">Delete Post</Typography>
+            </MenuItem>
+          </>
+        )}
+        <MenuItem sx={styles.menuItem} onClick={handleTemporary}>
+          <LinkIcon />
+          <Typography>Copy Link</Typography>
+        </MenuItem>
+      </Menu>
+    </>
+  );
+};
+
+export default PostMenu;

--- a/src/components/Posts/PostMenu.tsx
+++ b/src/components/Posts/PostMenu.tsx
@@ -10,10 +10,12 @@ import { useAppDispatch, useAppSelector } from "../../state/hooks";
 import { MoreVert, Edit, Delete, Link } from "@mui/icons-material";
 import axios from "axios";
 import { deletePost } from "../../state/slices/postsSlice";
+import { useNavigate } from "react-router-dom";
 
 type PostMenuProps = {
   authorId: number;
   postId: number;
+  isExpanded?: boolean;
 };
 
 const styles = {
@@ -26,21 +28,12 @@ const styles = {
   },
 };
 
-const PostMenu = ({ authorId, postId }: PostMenuProps) => {
+const PostMenu = ({ authorId, postId, isExpanded = false }: PostMenuProps) => {
   const userId = useAppSelector((state) => state.user.userId);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const dispatch = useAppDispatch();
-
-  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-    setMenuOpen(true);
-  };
-
-  const handleMenuClose = () => {
-    setAnchorEl(null);
-    setMenuOpen(false);
-  };
+  const navigate = useNavigate();
 
   const handleDelete = async () => {
     try {
@@ -53,13 +46,32 @@ const PostMenu = ({ authorId, postId }: PostMenuProps) => {
           },
         }
       );
-      dispatch(deletePost(postId));
+
+      isExpanded ? handleExpandedPostDelete() : handlePostDelete();
       return result.data;
     } catch (error) {
       console.error("Failed to delete the post", error);
     } finally {
       handleMenuClose();
     }
+  };
+
+  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+    setMenuOpen(true);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+    setMenuOpen(false);
+  };
+
+  const handlePostDelete = () => {
+    dispatch(deletePost(postId));
+  };
+
+  const handleExpandedPostDelete = () => {
+    navigate(-1);
   };
 
   const handleTemporary = () => {

--- a/src/components/Posts/PostMenu.tsx
+++ b/src/components/Posts/PostMenu.tsx
@@ -1,10 +1,13 @@
-import { IconButton, Menu, MenuItem, Typography } from "@mui/material";
+import {
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+} from "@mui/material";
 import React, { useState } from "react";
 import { useAppDispatch, useAppSelector } from "../../state/hooks";
-import MoreVertIcon from "@mui/icons-material/MoreVert";
-import EditIcon from "@mui/icons-material/Edit";
-import DeleteIcon from "@mui/icons-material/Delete";
-import LinkIcon from "@mui/icons-material/Link";
+import { MoreVert, Edit, Delete, Link } from "@mui/icons-material";
 import axios from "axios";
 import { deletePost } from "../../state/slices/postsSlice";
 
@@ -68,7 +71,7 @@ const PostMenu = ({ authorId, postId }: PostMenuProps) => {
   return (
     <>
       <IconButton onClick={handleMenuOpen}>
-        <MoreVertIcon />
+        <MoreVert />
       </IconButton>
       <Menu
         anchorEl={anchorEl}
@@ -80,12 +83,18 @@ const PostMenu = ({ authorId, postId }: PostMenuProps) => {
       >
         {userId === authorId && [
           <MenuItem sx={styles.menuItem} onClick={handleTemporary} key="edit">
-            <EditIcon />
-            <Typography>Edit Post</Typography>
+            <ListItemIcon>
+              <Edit />
+            </ListItemIcon>
+            <ListItemText>Edit Post</ListItemText>
           </MenuItem>,
           <MenuItem onClick={handleDelete} sx={styles.menuItem} key="delete">
-            <DeleteIcon color="error" />
-            <Typography color="error">Delete Post</Typography>
+            <ListItemIcon>
+              <Delete color="error" />
+            </ListItemIcon>
+            <ListItemText primaryTypographyProps={{ color: "error" }}>
+              Delete Post
+            </ListItemText>
           </MenuItem>,
         ]}
         <MenuItem
@@ -93,8 +102,10 @@ const PostMenu = ({ authorId, postId }: PostMenuProps) => {
           onClick={handleTemporary}
           key="copy-link"
         >
-          <LinkIcon />
-          <Typography>Copy Link</Typography>
+          <ListItemIcon>
+            <Link />
+          </ListItemIcon>
+          <ListItemText>Copy Link</ListItemText>
         </MenuItem>
       </Menu>
     </>

--- a/src/state/slices/postsSlice.ts
+++ b/src/state/slices/postsSlice.ts
@@ -117,6 +117,11 @@ export const postsSlice = createSlice({
           : o
       );
     },
+    deletePost: (state, action: PayloadAction<number>) => {
+      state.posts = state.posts.filter(
+        (post) => post.postId !== action.payload
+      );
+    },
   },
 });
 
@@ -128,6 +133,7 @@ export const {
   toggleLikePost,
   toggleFollow,
   updateDisplayNames,
+  deletePost,
 } = postsSlice.actions;
 
 export default postsSlice.reducer;


### PR DESCRIPTION
## Related Issues

Closes #93 and closes #112

## Summary

This branch includes two features. In this branch we create a post menu for each post item and expanded post item. This menu allows users to edit, delete posts and copy link of post. It is crucial that the author of the post is the only one with access to edit and delete the post. Copy link is public to anybody who has access to the post

The second feature is integrating deletion of the post functionality

## Changes Made

To start, I created a new `deletePost` reducer in the store for posts. This allowed me to instantly make changes to the post list. I created a delete request to the backend that passes parameters such as the postId and the userId. To use on both the expanded post item and post items, I created a reusable component called PostMenu that encapsulates most of the functionality in this PR

## Screenshots

<!-- If the changes are visual, including screenshots or GIFs can
help reviewers understand them more easily. -->

Open Menu

![Open Menu](https://github.com/Project-Chirp/chirp-frontend/assets/73755710/7862ab04-e46d-4fbb-b8e2-f33af43a74cb)

## Testing Instructions

<!-- Instructions on how to test the changes made in the pull
request, helping reviewers validate the code. -->

No additional testing instructions

## Special Notes for Your Reviewer(s)

The template is still up for debate so please do suggest any changes you think are appropriate
