### PR TITLE
T116, T117: Relevant user follow button bugs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,17 +5,23 @@ addresses, connecting the code's context with the problem it
 solves. Please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
 for keywords to link an issue -->
 
+Linked issue here
+
 ## Summary
 
 <!-- Provide a concise summary "Why are the changes needed"?
 Include any relevant links, such as Jira tickets, Slack discussions,
 or design documents. -->
 
+Your summary here
+
 ## Changes Made
 
 <!-- Describe the specific changes that have been made in this pull
 request. Provide details on the approach taken to address the problem
 and any notable implementation details. -->
+
+Your changes made here
 
 <!-- Optional Sections -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ or design documents. -->
 request. Provide details on the approach taken to address the problem
 and any notable implementation details. -->
 
-<!--> Optional Sections -->
+<!-- Optional Sections -->
 
 ## Screenshots
 

--- a/src/components/Posts/ExpandedPostItem.tsx
+++ b/src/components/Posts/ExpandedPostItem.tsx
@@ -48,7 +48,6 @@ const styles = {
     paddingY: 1,
   },
   actionCount: { fontWeight: "bold", paddingRight: 0.5 },
-  backButton: { "&:hover": { backgroundColor: "transparent" } },
   card: {
     padding: 0,
     boxShadow: "none",
@@ -71,7 +70,8 @@ const styles = {
   topHeader: {
     alignItems: "center",
     display: "flex",
-    paddingTop: 1,
+    gap: 2,
+    padding: 1,
   },
 };
 
@@ -110,10 +110,10 @@ const ExpandedPostItem = ({ post }: ExpandedPostItemProps) => {
   return (
     <Card sx={styles.card}>
       <Box sx={styles.topHeader}>
-        <IconButton onClick={() => navigate(-1)} sx={styles.backButton}>
+        <IconButton onClick={() => navigate(-1)}>
           <KeyboardBackspace color="secondary" />
         </IconButton>
-        <Typography variant="h2">Post</Typography>
+        <Typography variant="h3">Post</Typography>
       </Box>
       <CardHeader
         avatar={<UserAvatar username={post.username} />}

--- a/src/components/SideBar/RelevantUsers.tsx
+++ b/src/components/SideBar/RelevantUsers.tsx
@@ -33,6 +33,7 @@ const styles = {
 const RelevantUsers = () => {
   const theme = useTheme();
   const relevantUser = useAppSelector((state) => state.posts.expandedPost);
+  const currentUserId = useAppSelector((state) => state.user.userId);
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
 
@@ -68,18 +69,19 @@ const RelevantUsers = () => {
           }
           sx={styles.listItemText}
         />
-        {/* TODO: Remove this if the post is by the current user */}
-        {relevantUser.followStatus ? (
-          <FollowingButton
-            onClick={() => dispatch(toggleFollow())}
-            visitedUserId={relevantUser.userId}
-          />
-        ) : (
-          <FollowButton
-            onClick={() => dispatch(toggleFollow())}
-            visitedUserId={relevantUser.userId}
-          />
-        )}
+        {relevantUser.userId !== 0 &&
+          relevantUser.userId !== currentUserId &&
+          (relevantUser.followStatus ? (
+            <FollowingButton
+              onClick={() => dispatch(toggleFollow())}
+              visitedUserId={relevantUser.userId}
+            />
+          ) : (
+            <FollowButton
+              onClick={() => dispatch(toggleFollow())}
+              visitedUserId={relevantUser.userId}
+            />
+          ))}
       </ListItemButton>
     </Box>
   );

--- a/src/components/SideBar/RelevantUsers.tsx
+++ b/src/components/SideBar/RelevantUsers.tsx
@@ -71,12 +71,12 @@ const RelevantUsers = () => {
         {/* TODO: Remove this if the post is by the current user */}
         {relevantUser.followStatus ? (
           <FollowingButton
-            onClick={() => dispatch(toggleFollow(false))}
+            onClick={() => dispatch(toggleFollow())}
             visitedUserId={relevantUser.userId}
           />
         ) : (
           <FollowButton
-            onClick={() => dispatch(toggleFollow(true))}
+            onClick={() => dispatch(toggleFollow())}
             visitedUserId={relevantUser.userId}
           />
         )}

--- a/src/state/slices/postsSlice.ts
+++ b/src/state/slices/postsSlice.ts
@@ -104,8 +104,8 @@ export const postsSlice = createSlice({
           : state.expandedPost.numberOfLikes--;
       }
     },
-    toggleFollow: (state, action: PayloadAction<boolean>) => {
-      state.expandedPost.followStatus = !action.payload;
+    toggleFollow: (state) => {
+      state.expandedPost.followStatus = !state.expandedPost.followStatus;
     },
     updateDisplayNames: (
       state,


### PR DESCRIPTION
## Related Issues

Resolves #116 and resolves #117

## Summary

Some bugs were fixed for the relevant user follow buttons:

- We have hidden the follow button if the relevant user is the current user since they cannot follow themselves
- The follow button wasn't being displayed properly because the `toggleFollow` reducer also had some logic that was wrong

## Changes Made

- Added a conditional render to the `RelevantUsers` component that will hide the follow button if the current user is the user that made the post
- Refactored the `toggleFollow` reducer since a payload isn't needed for a toggle. Updated the `toggleFollow` calls within RelevantUsers


## Screenshots

<!-- If the changes are visual, including screenshots or GIFs can
help reviewers understand them more easily. -->

No additional screenshots

## Testing Instructions

<!-- Instructions on how to test the changes made in the pull
request, helping reviewers validate the code. -->

No additional testing instructions

## Special Notes for Your Reviewer(s)

<!-- If there are any specific instructions or considerations you
want to highlight for the reviewer, include them in this section. -->

No additional notes
